### PR TITLE
[Fix] 사용자 프로필 조회 projectId 선택 처리 #22

### DIFF
--- a/src/main/java/com/acc/local/controller/docs/AuthDocs.java
+++ b/src/main/java/com/acc/local/controller/docs/AuthDocs.java
@@ -100,7 +100,7 @@ public interface AuthDocs {
     ResponseEntity<LoginedUserProfileResponse> getLoginUserInformation(
         @Parameter(hidden = true)
         Authentication authentication,
-        @RequestParam
+        @RequestParam(required = false)
         @Parameter(description = "프로젝트 ID", required = false)
         String projectId
     );


### PR DESCRIPTION
## 작업 내용
- `/api/v1/auth/profile` 문서 인터페이스의 `projectId` 요청 파라미터를 선택값으로 변경했습니다.
- `projectId` 없이 프로필 조회 시 필수 파라미터 누락으로 500이 발생하지 않도록 처리했습니다.

## 확인 결과
- 현재 코드로 Docker app 이미지를 재빌드 후 서버 재실행했습니다.
- `acc-session-id` 쿠키를 포함해 `GET /api/v1/auth/profile` 요청을 확인했습니다.
- 요청:
```bash
curl -H "Cookie: acc-session-id=18521c92-6f06-4ea8-ba20-34f0126e0a7f" \
  http://localhost:8080/api/v1/auth/profile
```
- 응답 상태: `200 OK`
- 응답 본문:
```json
{
  "userName": "guswptest@ajou.ac.kr",
  "univ": {
    "grade": "1학년",
    "univDepartment": "소프트웨어및컴퓨터공학전공"
  },
  "project": null
}
```

## 테스트
- 별도 테스트 코드는 추가하지 않았습니다.
- 실제 로컬 서버 및 로그인 세션으로 API 동작을 확인했습니다.

Closes #22