### PR TITLE
[Fix] 관리자가 프로젝트 등록 승인 시 서버에러가 발생하는 문제 해결 #24

### DIFF
--- a/src/main/java/com/acc/local/external/adapters/keystone/KeystoneAPIExternalAdapter.java
+++ b/src/main/java/com/acc/local/external/adapters/keystone/KeystoneAPIExternalAdapter.java
@@ -74,6 +74,12 @@ public class KeystoneAPIExternalAdapter implements KeystoneAPIExternalPort {
 	}
 
 	@Override
+	public KeystoneToken getScopedTokenByPassword(String projectId, KeystonePasswordLoginRequest loginRequest) throws AccBaseException {
+		ResponseEntity<JsonNode> tokenResponse = authenticateKeystoneByPasswordWithScope(projectId, loginRequest);
+		return KeystoneAPIUtils.extractKeystoneToken(tokenResponse);
+	}
+
+	@Override
 	public KeystoneToken getAdminToken(KeystonePasswordLoginRequest loginRequest) throws AccBaseException {
 		KeystoneToken unscopedToken = getUnscopedToken(loginRequest);
 		// log.info("unscopedToken: {}", unscopedToken);
@@ -687,6 +693,31 @@ public class KeystoneAPIExternalAdapter implements KeystoneAPIExternalPort {
 				throw new KeystoneException(AuthErrorCode.UNAUTHORIZED);
 			}
 
+			return tokenResponse;
+		} catch (WebClientResponseException e) {
+			HttpStatusCode status = e.getStatusCode();
+			if (status == HttpStatus.UNAUTHORIZED) {
+				throw new KeystoneException(AuthErrorCode.UNAUTHORIZED, e);
+			} else if (status == HttpStatus.FORBIDDEN) {
+				throw new KeystoneException(AuthErrorCode.FORBIDDEN_ACCESS, e);
+			} else if (status == HttpStatus.BAD_REQUEST) {
+				throw new KeystoneException(AuthErrorCode.INVALID_REQUEST_PARAMETER, e);
+			}
+			throw new KeystoneException(AuthErrorCode.KEYSTONE_TOKEN_EXTRACTION_FAILED, e);
+		}
+	}
+
+	private ResponseEntity<JsonNode> authenticateKeystoneByPasswordWithScope(
+			String projectId,
+			KeystonePasswordLoginRequest loginRequest
+	) {
+		try {
+			Map<String, Object> tokenRequest =
+					KeystoneAPIUtils.createProjectScopePasswordAuthRequest(projectId, loginRequest);
+			ResponseEntity<JsonNode> tokenResponse = keystoneAuthAPIModule.issueScopedToken(tokenRequest);
+			if (tokenResponse == null) {
+				throw new KeystoneException(AuthErrorCode.KEYSTONE_TOKEN_EXTRACTION_FAILED);
+			}
 			return tokenResponse;
 		} catch (WebClientResponseException e) {
 			HttpStatusCode status = e.getStatusCode();

--- a/src/main/java/com/acc/local/external/modules/keystone/KeystoneAPIUtils.java
+++ b/src/main/java/com/acc/local/external/modules/keystone/KeystoneAPIUtils.java
@@ -369,6 +369,27 @@ public class KeystoneAPIUtils {
         return authRequest;
     }
 
+    public static Map<String, Object> createProjectScopePasswordAuthRequest(
+            String projectId,
+            KeystonePasswordLoginRequest request
+    ) {
+        Map<String, Object> authRequest = new HashMap<>();
+        authRequest.put("auth", Map.of(
+                "identity", Map.of(
+                        "methods", List.of("password"),
+                        "password", Map.of(
+                                "user", Map.of(
+                                        "name", request.username(),
+                                        "domain", Map.of("name", request.domainName()),
+                                        "password", request.password()
+                                )
+                        )
+                ),
+                "scope", Map.of("project", Map.of("id", projectId))
+        ));
+        return authRequest;
+    }
+
     public static Map<String, Object> createTokenAuthRequest(String existingToken) {
         Map<String, Object> authRequest = new HashMap<>();
         authRequest.put("auth", Map.of(

--- a/src/main/java/com/acc/local/external/ports/KeystoneAPIExternalPort.java
+++ b/src/main/java/com/acc/local/external/ports/KeystoneAPIExternalPort.java
@@ -28,6 +28,8 @@ public interface KeystoneAPIExternalPort {
 
 	KeystoneToken getScopedToken(String projectId, String unscopedToken) throws AccBaseException;
 
+	KeystoneToken getScopedTokenByPassword(String projectId, KeystonePasswordLoginRequest loginRequest) throws AccBaseException;
+
 	KeystoneToken getAdminToken(KeystonePasswordLoginRequest loginRequest) throws AccBaseException;
 
 	KeystoneToken getAdminTokenWithAdminProjectScope(KeystonePasswordLoginRequest loginRequest) throws AccBaseException;

--- a/src/main/java/com/acc/local/service/adapters/project/AdminProjectServiceAdapter.java
+++ b/src/main/java/com/acc/local/service/adapters/project/AdminProjectServiceAdapter.java
@@ -17,6 +17,7 @@ import com.acc.local.dto.project.quota.QuotaGroup;
 import com.acc.local.dto.project.quota.QuotaInformation;
 import com.acc.local.external.dto.keystone.KeystoneProject;
 import com.acc.local.service.modules.auth.AuthModule;
+import com.acc.local.service.modules.auth.KeystoneTokenModule;
 import com.acc.local.service.modules.auth.ProjectModule;
 import com.acc.local.service.modules.network.NeutronModule;
 import com.acc.local.service.modules.outbox.ProjectCreatedEvent;
@@ -42,6 +43,7 @@ public class AdminProjectServiceAdapter implements AdminProjectServicePort {
 	private final AuthModule authModule;
 	private final ProjectModule projectModule;
 	private final NeutronModule neutronModule;
+	private final KeystoneTokenModule keystoneTokenModule;
 	private final ApplicationEventPublisher eventPublisher;
 	private final SessionModule sessionModule;
 
@@ -51,14 +53,9 @@ public class AdminProjectServiceAdapter implements AdminProjectServicePort {
 		String userId = sessionModule.getKeystoneUserId(sessionId);
 		// TODO: userId를 통해, 요청을 보낸 사람이 Root인지 권한 확인
 		String adminToken = authModule.issueSystemAdminTokenWithAdminProjectScope(userId);
-		log.info(adminToken);
 
 		try {
 			return createProjectFromProjectCreateDto(createProjectRequest.toProjectCreateDto(), userId, adminToken);
-		} catch(Exception e) {
-			authModule.invalidateSystemAdminToken(adminToken);
-			e.printStackTrace();
-			throw e;
 		} finally {
 			authModule.invalidateSystemAdminToken(adminToken);
 		}
@@ -77,8 +74,12 @@ public class AdminProjectServiceAdapter implements AdminProjectServicePort {
 				adminToken
 		);
 
-		String projectOwnerScopedToken = authModule.issueProjectScopeToken(createdProjectId, projectOwnerId);
-		neutronModule.createDefaultNetwork(projectOwnerScopedToken);
+		String projectOwnerScopedToken = keystoneTokenModule.issueScopedTokenByUserCredentials(projectOwnerId, createdProjectId);
+		try {
+			neutronModule.createDefaultNetwork(projectOwnerScopedToken);
+		} finally {
+			keystoneTokenModule.revokeTokenQuietly(projectOwnerScopedToken);
+		}
 
 		// 프로젝트 생성 이벤트 발행
 		try {
@@ -157,49 +158,51 @@ public class AdminProjectServiceAdapter implements AdminProjectServicePort {
 		int appliedCount = 0;
 
 		List<ProjectRequestDto> projectRequestList = projectModule.getProjectRequestList(projectRequestIds);
-		for (ProjectRequestDto projectRequestDto: projectRequestList) {
-			String projectRequestId = projectRequestDto.projectRequestId();
-			if (!projectRequestDto.status().equals(ProjectRequestStatus.PENDING)) {
-				projectRequestAppliedResults.put(projectRequestId, DecisionApplyInfo.fail("이미 승인/반려여부가 결정된 프로젝트 요청입니다."));
-				continue;
-			}
-
-			try {
-				String createdProjectId = null;
-				if (decision == ProjectRequestStatus.APPROVED) {
-					CreateProjectResponse projectCreateResponse = createProjectFromProjectCreateDto(projectRequestDto.toProjectCreateDto(decidedUserId), decidedUserId, adminToken);
-					createdProjectId = projectCreateResponse.projectId();
+		try {
+			for (ProjectRequestDto projectRequestDto: projectRequestList) {
+				String projectRequestId = projectRequestDto.projectRequestId();
+				if (!projectRequestDto.status().equals(ProjectRequestStatus.PENDING)) {
+					projectRequestAppliedResults.put(projectRequestId, DecisionApplyInfo.fail("이미 승인/반려여부가 결정된 프로젝트 요청입니다."));
+					continue;
 				}
 
-				projectModule.updateStatus(projectRequestId, decision, rejectReason);
-				log.info(String.format("Project result: %s (%s) / Decided by %s", decision, projectRequestId, decidedUserId));
-				appliedCount++;
+				try {
+					String createdProjectId = null;
+					if (decision == ProjectRequestStatus.APPROVED) {
+						CreateProjectResponse projectCreateResponse = createProjectFromProjectCreateDto(projectRequestDto.toProjectCreateDto(decidedUserId), decidedUserId, adminToken);
+						createdProjectId = projectCreateResponse.projectId();
+					}
 
-				projectRequestAppliedResults.put(projectRequestId, DecisionApplyInfo.success(createdProjectId));
+					projectModule.updateStatus(projectRequestId, decision, rejectReason);
+					log.info(String.format("Project result: %s (%s) / Decided by %s", decision, projectRequestId, decidedUserId));
+					appliedCount++;
 
-				// 프로젝트 요청 결정 이벤트 발행
-				publishProjectRequestDecisionEvent(
-					projectRequestDto,
-					decision,
-					rejectReason,
-					decidedUserId,
-					createdProjectId
-				);
-			} catch(Exception e) {
-				projectRequestAppliedResults.put(projectRequestId, DecisionApplyInfo.fail(e.getMessage()));
-				log.error("Project Approve - Failed ({})", projectRequestId);
-				revertProjectDecision(projectRequestId, decidedUserId);
-				e.printStackTrace();
+					projectRequestAppliedResults.put(projectRequestId, DecisionApplyInfo.success(createdProjectId));
+
+					// 프로젝트 요청 결정 이벤트 발행
+					publishProjectRequestDecisionEvent(
+						projectRequestDto,
+						decision,
+						rejectReason,
+						decidedUserId,
+						createdProjectId
+					);
+				} catch(Exception e) {
+					projectRequestAppliedResults.put(projectRequestId, DecisionApplyInfo.fail(e.getMessage()));
+					log.error("Project Approve - Failed ({})", projectRequestId, e);
+					revertProjectDecision(projectRequestId, decidedUserId, adminToken, e);
+				}
 			}
-		}
-		authModule.invalidateSystemAdminToken(adminToken);
 
-		return DecideProjectRequestResponse.builder()
-				.requested(projectRequestIds.size())
-				.acknowledged(projectRequestList.size())
-				.applied(appliedCount)
-				.data(projectRequestAppliedResults)
-				.build();
+			return DecideProjectRequestResponse.builder()
+					.requested(projectRequestIds.size())
+					.acknowledged(projectRequestList.size())
+					.applied(appliedCount)
+					.data(projectRequestAppliedResults)
+					.build();
+		} finally {
+			authModule.invalidateSystemAdminToken(adminToken);
+		}
 	}
 
 	/**
@@ -236,32 +239,39 @@ public class AdminProjectServiceAdapter implements AdminProjectServicePort {
 		}
 	}
 
-    private void revertProjectDecision(String projectRequestId, String approvedUserId) {
-		String adminToken = authModule.issueSystemAdminTokenWithAdminProjectScope(approvedUserId);
-		try {
-			ProjectRequestDto projectRequest = projectModule.getProjectRequest(projectRequestId);
+    private void revertProjectDecision(
+			String projectRequestId,
+			String approvedUserId,
+			String adminToken,
+			Exception originalException
+	) {
+			try {
+				ProjectRequestDto projectRequest = projectModule.getProjectRequest(projectRequestId);
 
-			ProjectListServiceDto searchedProjectList = projectModule.getProjectList(projectRequest.projectName(), null, adminToken);
-			for (ProjectServiceDto projectDto: searchedProjectList.projects()) {
+				ProjectListServiceDto searchedProjectList = projectModule.getProjectList(projectRequest.projectName(), null, adminToken);
+				for (ProjectServiceDto projectDto: searchedProjectList.projects()) {
 				if (!projectDto.description().equals(
 						ProjectRequestDto.getProjectDescriptionMessage(projectRequest.projectRequestId(), approvedUserId)
 				)) {
 					continue;
 				}
 
-				String projectId = projectDto.projectId();
-				projectModule.deleteProject(projectId, approvedUserId);
-			}
+					String projectId = projectDto.projectId();
+					projectModule.deleteProjectWithToken(projectId, adminToken);
+				}
 
-			if (!projectRequest.status().equals(ProjectRequestStatus.PENDING)) {
-				projectModule.revertStatus(projectRequestId);
-			}
+				if (!projectRequest.status().equals(ProjectRequestStatus.PENDING)) {
+					projectModule.revertStatus(projectRequestId);
+				}
 
-		} catch (Exception e) {
-			throw new AuthServiceException(AuthErrorCode.KEYSTONE_API_FAILURE, "Openstack 프로젝트 정합성 복구에 실패했습니다");
-		} finally {
-			authModule.invalidateSystemAdminToken(adminToken);
-		}
+			} catch (Exception e) {
+				e.addSuppressed(originalException);
+				throw new AuthServiceException(
+						AuthErrorCode.KEYSTONE_API_FAILURE,
+						"Openstack 프로젝트 정합성 복구에 실패했습니다",
+						e
+				);
+			}
     }
 
 	@Override
@@ -269,15 +279,25 @@ public class AdminProjectServiceAdapter implements AdminProjectServicePort {
 		String requesterId = sessionModule.getKeystoneUserId(sessionId);
 		// TODO: requesterId를 통해, 요청을 보낸 사람이 Root or 해당 프로젝트 권한이 있는지 확인
 
-		KeystoneProject updatedProject = projectModule.updateProject(projectId, updateProjectRequest, requesterId);
-		return UpdateProjectResponse.from(updatedProject);
+		String adminToken = authModule.issueSystemAdminTokenWithAdminProjectScope(requesterId);
+		try {
+			KeystoneProject updatedProject = projectModule.updateProjectWithToken(projectId, updateProjectRequest, adminToken);
+			return UpdateProjectResponse.from(updatedProject);
+		} finally {
+			authModule.invalidateSystemAdminToken(adminToken);
+		}
 	}
 
 	@Override
 	public void deleteProject(String projectId, String sessionId) {
 		String requesterId = sessionModule.getKeystoneUserId(sessionId);
 		// TODO: requesterId를 통해, 요청을 보낸 사람이 Root or 해당 프로젝트 권한이 있는지 확인
-		projectModule.deleteProject(projectId, requesterId);
+		String adminToken = authModule.issueSystemAdminTokenWithAdminProjectScope(requesterId);
+		try {
+			projectModule.deleteProjectWithToken(projectId, adminToken);
+		} finally {
+			authModule.invalidateSystemAdminToken(adminToken);
+		}
 	}
 
 	@Override
@@ -290,7 +310,6 @@ public class AdminProjectServiceAdapter implements AdminProjectServicePort {
 		String requestUserId = sessionModule.getKeystoneUserId(sessionId);
 		// TODO: userId를 통해, 요청을 보낸 사람이 Root인지 권한 확인
 		String adminToken = authModule.issueSystemAdminTokenWithAdminProjectScope(requestUserId);
-		log.info(adminToken);
 
 		try {
 			ProjectListServiceDto projectServiceDataList = projectModule.getProjectList(keyword, pageRequest, adminToken);

--- a/src/main/java/com/acc/local/service/adapters/project/AdminProjectServiceAdapter.java
+++ b/src/main/java/com/acc/local/service/adapters/project/AdminProjectServiceAdapter.java
@@ -250,11 +250,12 @@ public class AdminProjectServiceAdapter implements AdminProjectServicePort {
 
 				ProjectListServiceDto searchedProjectList = projectModule.getProjectList(projectRequest.projectName(), null, adminToken);
 				for (ProjectServiceDto projectDto: searchedProjectList.projects()) {
-				if (!projectDto.description().equals(
-						ProjectRequestDto.getProjectDescriptionMessage(projectRequest.projectRequestId(), approvedUserId)
-				)) {
-					continue;
-				}
+					if (!Objects.equals(
+							projectDto.description(),
+							ProjectRequestDto.getProjectDescriptionMessage(projectRequest.projectRequestId(), approvedUserId)
+					)) {
+						continue;
+					}
 
 					String projectId = projectDto.projectId();
 					projectModule.deleteProjectWithToken(projectId, adminToken);

--- a/src/main/java/com/acc/local/service/modules/auth/KeystoneTokenModule.java
+++ b/src/main/java/com/acc/local/service/modules/auth/KeystoneTokenModule.java
@@ -61,7 +61,7 @@ public class KeystoneTokenModule {
     private void validateCredentials(UserDbExtraEntity user, String userId) {
         if (user.getKeystoneUsername() == null || user.getKeystonePassword() == null) {
             throw new AuthServiceException(
-                    AuthErrorCode.USER_NOT_FOUND,
+                    AuthErrorCode.NOT_FOUND_USER_AUTH_INFO,
                     "Keystone credentials가 없습니다. userId: " + userId
             );
         }

--- a/src/main/java/com/acc/local/service/modules/auth/KeystoneTokenModule.java
+++ b/src/main/java/com/acc/local/service/modules/auth/KeystoneTokenModule.java
@@ -1,0 +1,69 @@
+package com.acc.local.service.modules.auth;
+
+import com.acc.global.exception.auth.AuthErrorCode;
+import com.acc.global.exception.auth.AuthServiceException;
+import com.acc.global.security.crypto.KeystonePasswordEncryptor;
+import com.acc.local.dto.auth.KeystonePasswordLoginRequest;
+import com.acc.local.dto.auth.KeystoneToken;
+import com.acc.local.entity.UserDbExtraEntity;
+import com.acc.local.external.ports.KeystoneAPIExternalPort;
+import com.acc.local.repository.ports.UserRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KeystoneTokenModule {
+
+    private final UserRepositoryPort userRepositoryPort;
+    private final KeystoneAPIExternalPort keystoneAPIExternalPort;
+    private final KeystonePasswordEncryptor keystonePasswordEncryptor;
+
+    public KeystoneToken issueUnscopedTokenByUserCredentials(String userId) {
+        KeystonePasswordLoginRequest loginRequest = createLoginRequest(userId);
+        KeystoneToken token = keystoneAPIExternalPort.getUnscopedToken(loginRequest);
+        if (token == null) {
+            throw new AuthServiceException(AuthErrorCode.KEYSTONE_TOKEN_GENERATION_FAILED);
+        }
+        return token;
+    }
+
+    public String issueScopedTokenByUserCredentials(String userId, String projectId) {
+        KeystonePasswordLoginRequest loginRequest = createLoginRequest(userId);
+        KeystoneToken token = keystoneAPIExternalPort.getScopedTokenByPassword(projectId, loginRequest);
+        if (token == null) {
+            throw new AuthServiceException(AuthErrorCode.KEYSTONE_TOKEN_GENERATION_FAILED);
+        }
+        return token.token();
+    }
+
+    public void revokeTokenQuietly(String keystoneToken) {
+        if (keystoneToken == null || keystoneToken.isBlank()) {
+            return;
+        }
+        try {
+            keystoneAPIExternalPort.revokeToken(keystoneToken);
+        } catch (Exception e) {
+            log.warn("작업용 Keystone 토큰 폐기 실패", e);
+        }
+    }
+
+    private KeystonePasswordLoginRequest createLoginRequest(String userId) {
+        UserDbExtraEntity user = userRepositoryPort.findUserDetailById(userId)
+                .orElseThrow(() -> new AuthServiceException(AuthErrorCode.USER_NOT_FOUND));
+        validateCredentials(user, userId);
+        String password = keystonePasswordEncryptor.decrypt(user.getKeystonePassword());
+        return new KeystonePasswordLoginRequest(user.getKeystoneUsername(), password, "Default");
+    }
+
+    private void validateCredentials(UserDbExtraEntity user, String userId) {
+        if (user.getKeystoneUsername() == null || user.getKeystonePassword() == null) {
+            throw new AuthServiceException(
+                    AuthErrorCode.USER_NOT_FOUND,
+                    "Keystone credentials가 없습니다. userId: " + userId
+            );
+        }
+    }
+}

--- a/src/main/java/com/acc/local/service/modules/auth/ProjectModule.java
+++ b/src/main/java/com/acc/local/service/modules/auth/ProjectModule.java
@@ -328,7 +328,14 @@ public class ProjectModule {
 	}
 
 	@Transactional
+	@Deprecated
 	public KeystoneProject updateProject(String projectId, UpdateProjectRequest updatedProjectRequest, String requesterId) {
+		String keystoneToken = authModule.getUnscopedTokenByUserId(requesterId);
+		return updateProjectWithToken(projectId, updatedProjectRequest, keystoneToken);
+	}
+
+	@Transactional
+	public KeystoneProject updateProjectWithToken(String projectId, UpdateProjectRequest updatedProjectRequest, String keystoneToken) {
 		UpdateKeystoneProjectRequest updateRequest = UpdateKeystoneProjectRequest.builder()
 				.name(updatedProjectRequest.name())
 				.isDomain(updatedProjectRequest.isDomain())
@@ -338,14 +345,18 @@ public class ProjectModule {
 				.tags(updatedProjectRequest.tags())
 				.build();
 
-		String keystoneToken = authModule.getUnscopedTokenByUserId(requesterId);
 		return keystoneAPIExternalPort.updateProject(projectId, keystoneToken, updateRequest);
 	}
 
 	@Transactional
+	@Deprecated
 	public void deleteProject(String projectId, String requesterId) {
 		String keystoneToken = authModule.getUnscopedTokenByUserId(requesterId);
+		deleteProjectWithToken(projectId, keystoneToken);
+	}
 
+	@Transactional
+	public void deleteProjectWithToken(String projectId, String keystoneToken) {
 		keystoneAPIExternalPort.deleteProject(projectId, keystoneToken);
 	}
 

--- a/src/main/java/com/acc/local/service/modules/session/SessionModule.java
+++ b/src/main/java/com/acc/local/service/modules/session/SessionModule.java
@@ -1,21 +1,16 @@
 package com.acc.local.service.modules.session;
 
-import com.acc.global.exception.auth.AuthErrorCode;
-import com.acc.global.exception.auth.AuthServiceException;
 import com.acc.global.exception.session.SessionErrorCode;
 import com.acc.global.exception.session.SessionException;
-import com.acc.global.security.crypto.KeystonePasswordEncryptor;
 import com.acc.local.domain.model.session.KeycloakTokens;
 import com.acc.local.domain.model.session.KeystoneTokens;
 import com.acc.local.domain.model.session.SessionData;
-import com.acc.local.dto.auth.KeystonePasswordLoginRequest;
 import com.acc.local.dto.auth.KeystoneToken;
-import com.acc.local.entity.UserDbExtraEntity;
 import com.acc.local.external.dto.keycloak.KeycloakTokenResponse;
 import com.acc.local.external.ports.KeycloakOidcExternalPort;
 import com.acc.local.external.ports.KeystoneAPIExternalPort;
 import com.acc.local.repository.ports.SessionRepositoryPort;
-import com.acc.local.repository.ports.UserRepositoryPort;
+import com.acc.local.service.modules.auth.KeystoneTokenModule;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -51,10 +46,9 @@ import java.time.LocalDateTime;
 public class SessionModule {
 
     private final SessionRepositoryPort sessionRepositoryPort;
-    private final UserRepositoryPort userRepositoryPort;
     private final KeystoneAPIExternalPort keystoneAPIExternalPort;
     private final KeycloakOidcExternalPort keycloakOidcExternalPort;
-    private final KeystonePasswordEncryptor keystonePasswordEncryptor;
+    private final KeystoneTokenModule keystoneTokenModule;
 
     /**
      * 세션에서 Keystone unscoped token을 조회한다. 만료 시 자동 재발급.
@@ -145,20 +139,7 @@ public class SessionModule {
      */
     private String reissueKeystoneUnscopedToken(String sessionId, SessionData sessionData) {
         String keystoneUserId = sessionData.getKeystoneUserId();
-
-        UserDbExtraEntity userDetail = userRepositoryPort.findUserDetailById(keystoneUserId)
-                .orElseThrow(() -> new AuthServiceException(AuthErrorCode.USER_NOT_FOUND));
-
-        if (userDetail.getKeystoneUsername() == null || userDetail.getKeystonePassword() == null) {
-            throw new AuthServiceException(AuthErrorCode.USER_NOT_FOUND,
-                    "Keystone credentials가 없습니다. keystoneUserId: " + keystoneUserId);
-        }
-
-        String plainPassword = keystonePasswordEncryptor.decrypt(userDetail.getKeystonePassword());
-        KeystonePasswordLoginRequest loginRequest = new KeystonePasswordLoginRequest(
-                userDetail.getKeystoneUsername(), plainPassword, "Default");
-
-        KeystoneToken newToken = keystoneAPIExternalPort.getUnscopedToken(loginRequest);
+        KeystoneToken newToken = keystoneTokenModule.issueUnscopedTokenByUserCredentials(keystoneUserId);
 
         // 세션의 keystoneTokens 갱신
         KeystoneTokens updatedKeystoneTokens = KeystoneTokens.builder()

--- a/src/test/java/com/acc/local/external/adapters/keystone/KeystoneAPIExternalAdapterTest.java
+++ b/src/test/java/com/acc/local/external/adapters/keystone/KeystoneAPIExternalAdapterTest.java
@@ -7,9 +7,12 @@ import static org.mockito.Mockito.*;
 import java.util.Map;
 
 import com.acc.local.domain.enums.project.ProjectRole;
+import com.acc.local.dto.auth.UserKeystoneDto;
 import com.acc.local.external.dto.keystone.CreateKeystoneProjectRequest;
+import com.acc.local.external.dto.keystone.CreateKeystoneUserRequest;
 import com.acc.local.external.dto.keystone.KeystoneProject;
 import com.acc.local.external.dto.keystone.UpdateKeystoneProjectRequest;
+import com.acc.local.external.dto.keystone.UpdateKeystoneUserRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -222,19 +225,23 @@ class KeystoneAPIExternalAdapterTest {
 	void givenTokenAndUserRequest_whenCreateUser_thenReturnResponse() throws JsonProcessingException {
 		// given
 		String token = "test-token";
-		Map<String, Object> userRequest = Map.of("user", Map.of("name", "testUser"));
-		JsonNode responseBody = objectMapper.readTree("{\"user\": {\"id\": \"user-id\"}}");
+		CreateKeystoneUserRequest userRequest = CreateKeystoneUserRequest.builder()
+			.email("testUser@example.com")
+			.password("password")
+			.isEnable(true)
+			.build();
+		JsonNode responseBody = objectMapper.readTree("{\"user\": {\"id\": \"user-id\", \"name\": \"testUser\"}}");
 		ResponseEntity<JsonNode> expectedResponse = new ResponseEntity<>(responseBody, HttpStatus.CREATED);
 
-		when(keystoneUserAPIModule.createUser(token, userRequest)).thenReturn(expectedResponse);
+		when(keystoneUserAPIModule.createUser(token, userRequest.toKeystoneRequest())).thenReturn(expectedResponse);
 
 		// when
-		ResponseEntity<JsonNode> result = keystoneAPIExternalAdapter.createUser(token, userRequest);
+		UserKeystoneDto result = keystoneAPIExternalAdapter.createUser(token, userRequest);
 
 		// then
 		assertNotNull(result);
-		assertEquals(HttpStatus.CREATED, result.getStatusCode());
-		verify(keystoneUserAPIModule).createUser(token, userRequest);
+		assertEquals("user-id", result.id());
+		verify(keystoneUserAPIModule).createUser(token, userRequest.toKeystoneRequest());
 	}
 
 	@Test
@@ -249,11 +256,11 @@ class KeystoneAPIExternalAdapterTest {
 		when(keystoneUserAPIModule.getUserDetail(userId, token)).thenReturn(expectedResponse);
 
 		// when
-		ResponseEntity<JsonNode> result = keystoneAPIExternalAdapter.getUserDetail(userId, token);
+		UserKeystoneDto result = keystoneAPIExternalAdapter.getUserDetail(userId, token);
 
 		// then
 		assertNotNull(result);
-		assertEquals(HttpStatus.OK, result.getStatusCode());
+		assertEquals(userId, result.id());
 		verify(keystoneUserAPIModule).getUserDetail(userId, token);
 	}
 
@@ -263,19 +270,22 @@ class KeystoneAPIExternalAdapterTest {
 		// given
 		String userId = "test-user-id";
 		String token = "test-token";
-		Map<String, Object> userRequest = Map.of("user", Map.of("name", "updatedUser"));
-		JsonNode responseBody = objectMapper.readTree("{\"user\": {\"id\": \"" + userId + "\"}}");
+		UpdateKeystoneUserRequest userRequest = UpdateKeystoneUserRequest.builder()
+			.email("updatedUser@example.com")
+			.isEnable(true)
+			.build();
+		JsonNode responseBody = objectMapper.readTree("{\"user\": {\"id\": \"" + userId + "\", \"name\": \"updatedUser\"}}");
 		ResponseEntity<JsonNode> expectedResponse = new ResponseEntity<>(responseBody, HttpStatus.OK);
 
-		when(keystoneUserAPIModule.updateUser(userId, token, userRequest)).thenReturn(expectedResponse);
+		when(keystoneUserAPIModule.updateUser(userId, token, userRequest.toKeystoneRequest())).thenReturn(expectedResponse);
 
 		// when
-		ResponseEntity<JsonNode> result = keystoneAPIExternalAdapter.updateUser(userId, token, userRequest);
+		UserKeystoneDto result = keystoneAPIExternalAdapter.updateUser(userId, token, userRequest);
 
 		// then
 		assertNotNull(result);
-		assertEquals(HttpStatus.OK, result.getStatusCode());
-		verify(keystoneUserAPIModule).updateUser(userId, token, userRequest);
+		assertEquals(userId, result.id());
+		verify(keystoneUserAPIModule).updateUser(userId, token, userRequest.toKeystoneRequest());
 	}
 
 	@Test
@@ -284,16 +294,10 @@ class KeystoneAPIExternalAdapterTest {
 		// given
 		String userId = "test-user-id";
 		String token = "test-token";
-		JsonNode responseBody = objectMapper.readTree("{}");
-		ResponseEntity<JsonNode> expectedResponse = new ResponseEntity<>(responseBody, HttpStatus.NO_CONTENT);
-
-		when(keystoneUserAPIModule.deleteUser(userId, token)).thenReturn(expectedResponse);
-
 		// when
-		ResponseEntity<JsonNode> result = keystoneAPIExternalAdapter.deleteUser(userId, token);
+		keystoneAPIExternalAdapter.deleteUser(userId, token);
 
 		// then
-		assertNotNull(result);
 		verify(keystoneUserAPIModule).deleteUser(userId, token);
 	}
 
@@ -304,18 +308,21 @@ class KeystoneAPIExternalAdapterTest {
 	void givenTokenAndProjectRequest_whenCreateProject_thenReturnResponse() throws JsonProcessingException {
 		// given
 		String token = "test-token";
-		Map<String, Object> projectRequest = Map.of("project", Map.of("name", "testProject"));
-		JsonNode responseBody = objectMapper.readTree("{\"project\": {\"id\": \"project-id\"}}");
+		CreateKeystoneProjectRequest projectRequest = CreateKeystoneProjectRequest.builder()
+			.projectName("testProject")
+			.projectDescription("description")
+			.build();
+		JsonNode responseBody = objectMapper.readTree("{\"project\": {\"id\": \"project-id\", \"name\": \"testProject\"}}");
 		ResponseEntity<JsonNode> expectedResponse = new ResponseEntity<>(responseBody, HttpStatus.CREATED);
 
-		when(keystoneProjectAPIModule.createProject(token, projectRequest)).thenReturn(expectedResponse);
+		when(keystoneProjectAPIModule.createProject(token, projectRequest.toKeystoneRequest())).thenReturn(expectedResponse);
 
 		// when
-		KeystoneProject result = keystoneAPIExternalAdapter.createProject(token, CreateKeystoneProjectRequest.builder().build());
+		KeystoneProject result = keystoneAPIExternalAdapter.createProject(token, projectRequest);
 
 		// then
 		assertNotNull(result);
-		verify(keystoneProjectAPIModule).createProject(token, projectRequest);
+		verify(keystoneProjectAPIModule).createProject(token, projectRequest.toKeystoneRequest());
 	}
 
 	@Test
@@ -343,19 +350,21 @@ class KeystoneAPIExternalAdapterTest {
 		// given
 		String projectId = "test-project-id";
 		String token = "test-token";
-		Map<String, Object> projectRequest = Map.of("project", Map.of("name", "updatedProject"));
-		JsonNode responseBody = objectMapper.readTree("{\"project\": {\"id\": \"" + projectId + "\"}}");
+		UpdateKeystoneProjectRequest projectRequest = UpdateKeystoneProjectRequest.builder()
+			.name("updatedProject")
+			.build();
+		JsonNode responseBody = objectMapper.readTree("{\"project\": {\"id\": \"" + projectId + "\", \"name\": \"updatedProject\"}}");
 		ResponseEntity<JsonNode> expectedResponse = new ResponseEntity<>(responseBody, HttpStatus.OK);
 
-		when(keystoneProjectAPIModule.updateProject(projectId, token, projectRequest)).thenReturn(expectedResponse);
+		when(keystoneProjectAPIModule.updateProject(projectId, token, projectRequest.toKeystoneRequest())).thenReturn(expectedResponse);
 
 		// when
-		KeystoneProject result = keystoneAPIExternalAdapter.updateProject(projectId, token, UpdateKeystoneProjectRequest.builder().build());
+		KeystoneProject result = keystoneAPIExternalAdapter.updateProject(projectId, token, projectRequest);
 
 		// then
 		assertNotNull(result);
-//		assertEquals(HttpStatus.OK, result.getStatusCode());
-		verify(keystoneProjectAPIModule).updateProject(projectId, token, projectRequest);
+	//		assertEquals(HttpStatus.OK, result.getStatusCode());
+		verify(keystoneProjectAPIModule).updateProject(projectId, token, projectRequest.toKeystoneRequest());
 	}
 
 	@Test

--- a/src/test/java/com/acc/local/service/adapters/project/AdminProjectServiceAdapterTest.java
+++ b/src/test/java/com/acc/local/service/adapters/project/AdminProjectServiceAdapterTest.java
@@ -1,0 +1,142 @@
+package com.acc.local.service.adapters.project;
+
+import com.acc.local.domain.enums.project.ProjectRequestStatus;
+import com.acc.local.dto.project.DecideProjectRequestResponse;
+import com.acc.local.dto.project.ProjectListServiceDto;
+import com.acc.local.dto.project.ProjectRequestDto;
+import com.acc.local.dto.project.ProjectServiceDto;
+import com.acc.local.dto.project.quota.ProjectGlobalQuotaDto;
+import com.acc.local.external.dto.keystone.KeystoneProject;
+import com.acc.local.service.modules.auth.AuthModule;
+import com.acc.local.service.modules.auth.KeystoneTokenModule;
+import com.acc.local.service.modules.auth.ProjectModule;
+import com.acc.local.service.modules.network.NeutronModule;
+import com.acc.local.service.modules.session.SessionModule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class AdminProjectServiceAdapterTest {
+
+    @Mock
+    private AuthModule authModule;
+
+    @Mock
+    private ProjectModule projectModule;
+
+    @Mock
+    private NeutronModule neutronModule;
+
+    @Mock
+    private KeystoneTokenModule keystoneTokenModule;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private SessionModule sessionModule;
+
+    @InjectMocks
+    private AdminProjectServiceAdapter adminProjectServiceAdapter;
+
+    @Test
+    @DisplayName("프로젝트 요청 승인 시 프로젝트 소유자 credential로 작업용 스코프 토큰을 발급한다.")
+    void givenPendingProjectRequest_whenApproveProjectRequest_thenUseOwnerCredentialScopedToken() {
+        // given
+        String sessionId = "session-id";
+        String adminUserId = "admin-user-id";
+        String ownerUserId = "owner-user-id";
+        String adminToken = "admin-token";
+        String ownerToken = "owner-scoped-token";
+        String projectId = "created-project-id";
+        ProjectRequestDto request = createPendingProjectRequest(ownerUserId);
+        KeystoneProject createdProject = KeystoneProject.builder().id(projectId).name("project").build();
+
+        given(sessionModule.getKeystoneUserId(sessionId)).willReturn(adminUserId);
+        given(authModule.issueSystemAdminTokenWithAdminProjectScope(adminUserId)).willReturn(adminToken);
+        given(projectModule.getProjectRequestList(List.of("request-id"))).willReturn(List.of(request));
+        given(projectModule.createProject(eq(adminToken), any(), eq(adminUserId))).willReturn(createdProject);
+        given(keystoneTokenModule.issueScopedTokenByUserCredentials(ownerUserId, projectId)).willReturn(ownerToken);
+
+        // when
+        DecideProjectRequestResponse response = adminProjectServiceAdapter.applyProjectRequestDecisions(
+                List.of("request-id"), ProjectRequestStatus.APPROVED, null, sessionId);
+
+        // then
+        assertThat(response.applied()).isEqualTo(1);
+        then(neutronModule).should().createDefaultNetwork(ownerToken);
+        then(keystoneTokenModule).should().revokeTokenQuietly(ownerToken);
+        then(authModule).should(never()).issueProjectScopeToken(anyString(), anyString());
+        then(authModule).should().invalidateSystemAdminToken(adminToken);
+    }
+
+    @Test
+    @DisplayName("프로젝트 승인 실패 후 복구 시 승인자의 legacy user_tokens를 조회하지 않는다.")
+    void givenDefaultNetworkFailure_whenApproveProjectRequest_thenRollbackWithAdminToken() {
+        // given
+        String sessionId = "session-id";
+        String adminUserId = "admin-user-id";
+        String ownerUserId = "owner-user-id";
+        String adminToken = "admin-token";
+        String ownerToken = "owner-scoped-token";
+        String projectId = "created-project-id";
+        ProjectRequestDto request = createPendingProjectRequest(ownerUserId);
+        KeystoneProject createdProject = KeystoneProject.builder().id(projectId).name("project").build();
+        ProjectServiceDto rollbackProject = createRollbackProject(projectId, adminUserId);
+
+        given(sessionModule.getKeystoneUserId(sessionId)).willReturn(adminUserId);
+        given(authModule.issueSystemAdminTokenWithAdminProjectScope(adminUserId)).willReturn(adminToken);
+        given(projectModule.getProjectRequestList(List.of("request-id"))).willReturn(List.of(request));
+        given(projectModule.createProject(eq(adminToken), any(), eq(adminUserId))).willReturn(createdProject);
+        given(keystoneTokenModule.issueScopedTokenByUserCredentials(ownerUserId, projectId)).willReturn(ownerToken);
+        willThrow(new RuntimeException("network failed")).given(neutronModule).createDefaultNetwork(ownerToken);
+        given(projectModule.getProjectRequest("request-id")).willReturn(request);
+        given(projectModule.getProjectList("project", null, adminToken))
+                .willReturn(ProjectListServiceDto.builder().projects(List.of(rollbackProject)).build());
+
+        // when
+        DecideProjectRequestResponse response = adminProjectServiceAdapter.applyProjectRequestDecisions(
+                List.of("request-id"), ProjectRequestStatus.APPROVED, null, sessionId);
+
+        // then
+        assertThat(response.applied()).isZero();
+        then(projectModule).should().deleteProjectWithToken(projectId, adminToken);
+        then(authModule).should(never()).getUnscopedTokenByUserId(anyString());
+        then(authModule).should().invalidateSystemAdminToken(adminToken);
+    }
+
+    private ProjectRequestDto createPendingProjectRequest(String ownerUserId) {
+        return ProjectRequestDto.builder()
+                .projectRequestId("request-id")
+                .projectName("project")
+                .requestUserId(ownerUserId)
+                .description("description")
+                .status(ProjectRequestStatus.PENDING)
+                .projectBrief(ProjectGlobalQuotaDto.getDefault())
+                .build();
+    }
+
+    private ProjectServiceDto createRollbackProject(String projectId, String adminUserId) {
+        return ProjectServiceDto.builder()
+                .projectId(projectId)
+                .projectName("project")
+                .description(ProjectRequestDto.getProjectDescriptionMessage("request-id", adminUserId))
+                .build();
+    }
+}

--- a/src/test/java/com/acc/local/service/adapters/snapshot/policy/SnapshotPolicyServiceAdapterTest.java
+++ b/src/test/java/com/acc/local/service/adapters/snapshot/policy/SnapshotPolicyServiceAdapterTest.java
@@ -36,8 +36,8 @@ class SnapshotPolicyServiceAdapterTest {
     @Mock
     private VolumeModule volumeModule;
 
-	@Mock
-	private SessionModule sessionModule;
+    @Mock
+    private SessionModule sessionModule;
 
     @InjectMocks
     private SnapshotPolicyServiceAdapter policyServiceAdapter;

--- a/src/test/java/com/acc/local/service/adapters/snapshot/policy/SnapshotPolicyServiceAdapterTest.java
+++ b/src/test/java/com/acc/local/service/adapters/snapshot/policy/SnapshotPolicyServiceAdapterTest.java
@@ -7,7 +7,7 @@ import com.acc.global.exception.volume.VolumeException;
 import com.acc.local.domain.enums.IntervalType;
 import com.acc.local.dto.snapshot.policy.SnapshotPolicyRequest;
 import com.acc.local.dto.snapshot.policy.SnapshotPolicyResponse;
-import com.acc.local.service.modules.auth.AuthModule;
+import com.acc.local.service.modules.session.SessionModule;
 import com.acc.local.service.modules.snapshot.policy.SnapshotPolicyModule;
 import com.acc.local.service.modules.volume.VolumeModule;
 import org.junit.jupiter.api.DisplayName;
@@ -36,8 +36,8 @@ class SnapshotPolicyServiceAdapterTest {
     @Mock
     private VolumeModule volumeModule;
 
-    @Mock
-    private AuthModule authModule;
+	@Mock
+	private SessionModule sessionModule;
 
     @InjectMocks
     private SnapshotPolicyServiceAdapter policyServiceAdapter;
@@ -46,7 +46,6 @@ class SnapshotPolicyServiceAdapterTest {
     @DisplayName("정책 목록을 페이징하여 조회할 수 있다")
     void givenPageRequest_whenGetPolicies_thenReturnPageResponse() {
         // given
-        String userId = "test-user-id";
         String projectId = "test-project-id";
         PageRequest pageRequest = new PageRequest();
         pageRequest.setMarker("0");
@@ -87,7 +86,7 @@ class SnapshotPolicyServiceAdapterTest {
         when(policyModule.toPageResponse(expectedPage, pageRequest)).thenReturn(expectedResponse);
 
         // when
-        PageResponse<SnapshotPolicyResponse> actualPage = policyServiceAdapter.getPolicies(pageRequest, userId, projectId);
+        PageResponse<SnapshotPolicyResponse> actualPage = policyServiceAdapter.getPolicies(pageRequest, projectId);
 
         // then
         assertNotNull(actualPage);
@@ -103,7 +102,6 @@ class SnapshotPolicyServiceAdapterTest {
     void givenValidPolicyId_whenGetPolicyDetails_thenReturnPolicyResponse() {
         // given
         Long policyId = 1L;
-        String userId = "test-user-id";
         String projectId = "test-project-id";
 
         SnapshotPolicyResponse expectedPolicy = SnapshotPolicyResponse.builder()
@@ -119,7 +117,7 @@ class SnapshotPolicyServiceAdapterTest {
         when(policyModule.getPolicyDetails(policyId, projectId)).thenReturn(expectedPolicy);
 
         // when
-        SnapshotPolicyResponse actualPolicy = policyServiceAdapter.getPolicyDetails(policyId, userId, projectId);
+        SnapshotPolicyResponse actualPolicy = policyServiceAdapter.getPolicyDetails(policyId, projectId);
 
         // then
         assertNotNull(actualPolicy);
@@ -139,7 +137,7 @@ class SnapshotPolicyServiceAdapterTest {
 
         // when & then
         VolumeException exception = assertThrows(VolumeException.class,
-                () -> policyServiceAdapter.getPolicyDetails(invalidPolicyId, "user", "project"));
+                () -> policyServiceAdapter.getPolicyDetails(invalidPolicyId, "project"));
 
         assertEquals(VolumeErrorCode.INVALID_POLICY_ID, exception.getErrorCode());
         verify(policyModule, never()).getPolicyDetails(anyLong(), anyString());
@@ -166,22 +164,22 @@ class SnapshotPolicyServiceAdapterTest {
                 .dailyTime(LocalTime.of(2, 0))
                 .build();
 
-        String userId = "test-user-id";
+        String sessionId = "test-session-id";
         String projectId = "test-project-id";
 
         when(policyModule.createPolicy(request, projectId)).thenReturn(expectedPolicy);
-        when(authModule.issueProjectScopeToken(projectId, userId)).thenReturn("keystone-token");
+        when(sessionModule.getKeystoneScopedToken(sessionId, projectId)).thenReturn("keystone-token");
         when(volumeModule.getVolumeDetails("keystone-token", projectId, "volume-1")).thenReturn(null);
 
         // when
-        SnapshotPolicyResponse actualPolicy = policyServiceAdapter.createPolicy(request, userId, projectId);
+        SnapshotPolicyResponse actualPolicy = policyServiceAdapter.createPolicy(request, sessionId, projectId);
 
         // then
         assertNotNull(actualPolicy);
         assertEquals(1L, actualPolicy.getPolicyId());
         assertEquals("daily-backup", actualPolicy.getName());
         verify(policyModule).validateRequest(request);
-        verify(authModule).issueProjectScopeToken(projectId, userId);
+        verify(sessionModule).getKeystoneScopedToken(sessionId, projectId);
         verify(volumeModule).getVolumeDetails("keystone-token", projectId, "volume-1");
         verify(policyModule).createPolicy(request, projectId);
     }
@@ -195,7 +193,7 @@ class SnapshotPolicyServiceAdapterTest {
         request.setVolumeId("volume-1");
         request.setIntervalType(IntervalType.DAILY);
 
-        String userId = "test-user-id";
+        String sessionId = "test-session-id";
         String projectId = "test-project-id";
 
         doThrow(new VolumeException(VolumeErrorCode.INVALID_POLICY_NAME))
@@ -203,7 +201,7 @@ class SnapshotPolicyServiceAdapterTest {
 
         // when & then
         VolumeException exception = assertThrows(VolumeException.class,
-                () -> policyServiceAdapter.createPolicy(request, userId, projectId));
+                () -> policyServiceAdapter.createPolicy(request, sessionId, projectId));
 
         assertEquals(VolumeErrorCode.INVALID_POLICY_NAME, exception.getErrorCode());
         verify(policyModule, never()).createPolicy(any(), anyString());
@@ -214,14 +212,13 @@ class SnapshotPolicyServiceAdapterTest {
     void givenValidPolicyId_whenActivatePolicy_thenSuccess() {
         // given
         Long policyId = 1L;
-        String userId = "test-user-id";
         String projectId = "test-project-id";
 
         doNothing().when(policyModule).activatePolicy(policyId, projectId);
 
         // when & then
         assertDoesNotThrow(() -> {
-            policyServiceAdapter.activatePolicy(policyId, userId, projectId);
+            policyServiceAdapter.activatePolicy(policyId, projectId);
         });
 
         verify(policyModule).activatePolicy(policyId, projectId);
@@ -232,14 +229,13 @@ class SnapshotPolicyServiceAdapterTest {
     void givenValidPolicyId_whenDeactivatePolicy_thenSuccess() {
         // given
         Long policyId = 1L;
-        String userId = "test-user-id";
         String projectId = "test-project-id";
 
         doNothing().when(policyModule).deactivatePolicy(policyId, projectId);
 
         // when & then
         assertDoesNotThrow(() -> {
-            policyServiceAdapter.deactivatePolicy(policyId, userId, projectId);
+            policyServiceAdapter.deactivatePolicy(policyId, projectId);
         });
 
         verify(policyModule).deactivatePolicy(policyId, projectId);

--- a/src/test/java/com/acc/local/service/adapters/volume/VolumeServiceAdapterTest.java
+++ b/src/test/java/com/acc/local/service/adapters/volume/VolumeServiceAdapterTest.java
@@ -6,7 +6,7 @@ import com.acc.global.exception.volume.VolumeErrorCode;
 import com.acc.global.exception.volume.VolumeException;
 import com.acc.local.dto.volume.VolumeRequest;
 import com.acc.local.dto.volume.VolumeResponse;
-import com.acc.local.service.modules.auth.AuthModule;
+import com.acc.local.service.modules.session.SessionModule;
 import com.acc.local.service.modules.volume.VolumeModule;
 import com.acc.local.service.modules.volume.VolumeUtil;
 import org.junit.jupiter.api.DisplayName;
@@ -35,7 +35,7 @@ class VolumeServiceAdapterTest {
     private VolumeUtil volumeUtil;
 
     @Mock
-    private AuthModule authModule;
+    private SessionModule sessionModule;
 
     @InjectMocks
     private VolumeServiceAdapter volumeServiceAdapter;
@@ -73,7 +73,7 @@ class VolumeServiceAdapterTest {
                 .last(true)
                 .build();
 
-        when(authModule.issueProjectScopeToken(projectId, userId)).thenReturn(keystoneToken);
+        when(sessionModule.getKeystoneScopedToken(userId, projectId)).thenReturn(keystoneToken);
         when(volumeModule.getVolumes(eq(pageRequest), eq(projectId), eq(keystoneToken)))
                 .thenReturn(expectedResponse);
 
@@ -109,7 +109,7 @@ class VolumeServiceAdapterTest {
                 .bootable("false")
                 .build();
 
-        when(authModule.issueProjectScopeToken(projectId, userId)).thenReturn(keystoneToken);
+        when(sessionModule.getKeystoneScopedToken(userId, projectId)).thenReturn(keystoneToken);
         when(volumeUtil.validateVolumeId(volumeId)).thenReturn(true);
         when(volumeModule.getVolumeDetails(eq(keystoneToken), eq(projectId), eq(volumeId)))
                 .thenReturn(expectedVolume);
@@ -135,7 +135,7 @@ class VolumeServiceAdapterTest {
         String keystoneToken = "test-keystone-token";
         String invalidVolumeId = "invalid-id";
 
-        when(authModule.issueProjectScopeToken(projectId, userId)).thenReturn(keystoneToken);
+        when(sessionModule.getKeystoneScopedToken(userId, projectId)).thenReturn(keystoneToken);
         when(volumeUtil.validateVolumeId(invalidVolumeId)).thenReturn(false);
 
         // when & then
@@ -170,7 +170,7 @@ class VolumeServiceAdapterTest {
                 .description("New test volume")
                 .build();
 
-        when(authModule.issueProjectScopeToken(projectId, userId)).thenReturn(keystoneToken);
+        when(sessionModule.getKeystoneScopedToken(userId, projectId)).thenReturn(keystoneToken);
         when(volumeUtil.validateVolumeSize(10)).thenReturn(true);
         when(volumeUtil.validateVolumeName("new-volume")).thenReturn(true);
         when(volumeModule.createVolume(eq(keystoneToken), eq(projectId), eq(request)))
@@ -200,6 +200,7 @@ class VolumeServiceAdapterTest {
         request.setName("new-volume");
         request.setSize(0);
 
+        when(sessionModule.getKeystoneScopedToken(userId, projectId)).thenReturn(keystoneToken);
         when(volumeUtil.validateVolumeSize(0)).thenReturn(false);
 
         // when & then
@@ -223,6 +224,7 @@ class VolumeServiceAdapterTest {
         request.setName("!invalid-name");
         request.setSize(10);
 
+        when(sessionModule.getKeystoneScopedToken(userId, projectId)).thenReturn(keystoneToken);
         when(volumeUtil.validateVolumeSize(10)).thenReturn(true);
         when(volumeUtil.validateVolumeName("!invalid-name")).thenReturn(false);
 
@@ -246,7 +248,7 @@ class VolumeServiceAdapterTest {
         String keystoneToken = "test-keystone-token";
         String volumeId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
 
-        when(authModule.issueProjectScopeToken(projectId, userId)).thenReturn(keystoneToken);
+        when(sessionModule.getKeystoneScopedToken(userId, projectId)).thenReturn(keystoneToken);
         when(volumeUtil.validateVolumeId(volumeId)).thenReturn(true);
         when(volumeModule.deleteVolume(eq(keystoneToken), eq(projectId), eq(volumeId)))
                 .thenReturn(ResponseEntity.status(HttpStatus.ACCEPTED).build());
@@ -270,6 +272,7 @@ class VolumeServiceAdapterTest {
         String keystoneToken = "test-keystone-token";
         String invalidVolumeId = "invalid-id";
 
+        when(sessionModule.getKeystoneScopedToken(userId, projectId)).thenReturn(keystoneToken);
         when(volumeUtil.validateVolumeId(invalidVolumeId)).thenReturn(false);
 
         // when & then

--- a/src/test/java/com/acc/local/service/adapters/volume/snapshot/VolumeSnapshotServiceAdapterTest.java
+++ b/src/test/java/com/acc/local/service/adapters/volume/snapshot/VolumeSnapshotServiceAdapterTest.java
@@ -6,7 +6,7 @@ import com.acc.global.exception.volume.VolumeErrorCode;
 import com.acc.global.exception.volume.VolumeException;
 import com.acc.local.dto.volume.snapshot.VolumeSnapshotRequest;
 import com.acc.local.dto.volume.snapshot.VolumeSnapshotResponse;
-import com.acc.local.service.modules.auth.AuthModule;
+import com.acc.local.service.modules.session.SessionModule;
 import com.acc.local.service.modules.volume.snapshot.VolumeSnapshotModule;
 import com.acc.local.service.modules.volume.snapshot.VolumeSnapshotUtil;
 import org.junit.jupiter.api.DisplayName;
@@ -35,7 +35,7 @@ class VolumeSnapshotServiceAdapterTest {
     private VolumeSnapshotUtil volumeSnapshotUtil;
 
     @Mock
-    private AuthModule authModule;
+    private SessionModule sessionModule;
 
     @InjectMocks
     private VolumeSnapshotServiceAdapter volumeSnapshotServiceAdapter;
@@ -75,8 +75,8 @@ class VolumeSnapshotServiceAdapterTest {
                 .last(true)
                 .build();
 
-        when(authModule.issueProjectScopeToken(projectId, userId)).thenReturn(keystoneToken);
-        when(volumeSnapshotModule.getSnapshots(eq(pageRequest), eq(projectId), eq(keystoneToken)))
+        when(sessionModule.getKeystoneScopedToken(userId, projectId)).thenReturn(keystoneToken);
+        when(volumeSnapshotModule.getSnapshots(eq(keystoneToken), eq(projectId), eq(pageRequest)))
                 .thenReturn(expectedResponse);
 
         // when
@@ -86,7 +86,7 @@ class VolumeSnapshotServiceAdapterTest {
         assertNotNull(actualResponse);
         assertEquals(2, actualResponse.getSize());
         assertEquals("snapshot-1", actualResponse.getContents().get(0).getSnapshotId());
-        verify(volumeSnapshotModule).getSnapshots(eq(pageRequest), eq(projectId), eq(keystoneToken));
+        verify(volumeSnapshotModule).getSnapshots(eq(keystoneToken), eq(projectId), eq(pageRequest));
     }
 
     @Test
@@ -107,7 +107,7 @@ class VolumeSnapshotServiceAdapterTest {
                 .createdAt("2025-01-01T00:00:00.000000")
                 .build();
 
-        when(authModule.issueProjectScopeToken(projectId, userId)).thenReturn(keystoneToken);
+        when(sessionModule.getKeystoneScopedToken(userId, projectId)).thenReturn(keystoneToken);
         when(volumeSnapshotUtil.validateSnapshotId(snapshotId)).thenReturn(true);
         when(volumeSnapshotModule.getSnapshotDetails(eq(keystoneToken), eq(projectId), eq(snapshotId)))
                 .thenReturn(expectedSnapshot);
@@ -132,7 +132,7 @@ class VolumeSnapshotServiceAdapterTest {
         String keystoneToken = "test-keystone-token";
         String invalidSnapshotId = "invalid-id";
 
-        when(authModule.issueProjectScopeToken(projectId, userId)).thenReturn(keystoneToken);
+        when(sessionModule.getKeystoneScopedToken(userId, projectId)).thenReturn(keystoneToken);
         when(volumeSnapshotUtil.validateSnapshotId(invalidSnapshotId)).thenReturn(false);
 
         // when & then
@@ -164,7 +164,7 @@ class VolumeSnapshotServiceAdapterTest {
                 .sourceVolumeId("b8f6a3b2-9d3a-4a6e-8b1e-2e4a6d8c2e1f")
                 .build();
 
-        when(authModule.issueProjectScopeToken(projectId, userId)).thenReturn(keystoneToken);
+        when(sessionModule.getKeystoneScopedToken(userId, projectId)).thenReturn(keystoneToken);
         when(volumeSnapshotUtil.validateVolumeId(request.getSourceVolumeId())).thenReturn(true);
         when(volumeSnapshotUtil.validateSnapshotName(request.getName())).thenReturn(true);
         when(volumeSnapshotModule.createSnapshot(eq(keystoneToken), eq(projectId), eq(request)))
@@ -214,7 +214,7 @@ class VolumeSnapshotServiceAdapterTest {
         String keystoneToken = "test-keystone-token";
         String snapshotId = "e1f2a3b4-c5d6-e7f8-a9b0-c1d2e3f4a5b6";
 
-        when(authModule.issueProjectScopeToken(projectId, userId)).thenReturn(keystoneToken);
+        when(sessionModule.getKeystoneScopedToken(userId, projectId)).thenReturn(keystoneToken);
         when(volumeSnapshotUtil.validateSnapshotId(snapshotId)).thenReturn(true);
         when(volumeSnapshotModule.deleteSnapshot(eq(keystoneToken), eq(projectId), eq(snapshotId)))
                 .thenReturn(ResponseEntity.status(HttpStatus.ACCEPTED).build());

--- a/src/test/java/com/acc/local/service/modules/auth/AuthModuleTest.java
+++ b/src/test/java/com/acc/local/service/modules/auth/AuthModuleTest.java
@@ -34,6 +34,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import java.security.InvalidParameterException;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -556,6 +557,12 @@ class AuthModuleTest {
 
         when(keystoneAPIExternalPort.getUnscopedToken(request)).thenReturn(mockKeystoneToken);
         when(userTokenRepositoryPort.findAllByUserIdAndIsActiveTrue(userId)).thenReturn(List.of());
+        when(userRepositoryPort.findUserDetailById(userId)).thenReturn(Optional.of(
+            UserDbExtraEntity.builder()
+                .userId(userId)
+                .isDeleted(false)
+                .build()
+        ));
         when(jwtUtils.generateToken(userId)).thenReturn(expectedAccessToken);
 
         UserTokenEntity savedEntity = mock(UserTokenEntity.class);
@@ -658,13 +665,6 @@ class AuthModuleTest {
         when(userRepositoryPort.saveUserIdentity(any(UserIdentityEntity.class)))
                 .thenReturn(savedUserAuthDetail);
 
-        when(keystoneAPIExternalPort.getTokenObject(any())).thenReturn(
-            KeystoneToken.builder()
-                .token(adminToken)
-                .isAdmin(true)
-                .build()
-        );
-
         // when
         String resultUserId = authModule.signup(signupRequest, adminToken);
 
@@ -673,6 +673,5 @@ class AuthModuleTest {
         verify(keystoneAPIExternalPort).createUser(eq(adminToken), any());
         verify(userRepositoryPort).saveUserDetail(any(UserDbExtraEntity.class));
         verify(userRepositoryPort).saveUserIdentity(any(UserIdentityEntity.class));
-        verify(keystoneAPIExternalPort).revokeToken(adminToken);
     }
 }

--- a/src/test/java/com/acc/local/service/modules/auth/KeystoneTokenModuleTest.java
+++ b/src/test/java/com/acc/local/service/modules/auth/KeystoneTokenModuleTest.java
@@ -1,0 +1,104 @@
+package com.acc.local.service.modules.auth;
+
+import com.acc.global.exception.auth.AuthServiceException;
+import com.acc.global.security.crypto.KeystonePasswordEncryptor;
+import com.acc.local.dto.auth.KeystonePasswordLoginRequest;
+import com.acc.local.dto.auth.KeystoneToken;
+import com.acc.local.entity.UserDbExtraEntity;
+import com.acc.local.external.ports.KeystoneAPIExternalPort;
+import com.acc.local.repository.ports.UserRepositoryPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+
+@ExtendWith(MockitoExtension.class)
+class KeystoneTokenModuleTest {
+
+    @Mock
+    private UserRepositoryPort userRepositoryPort;
+
+    @Mock
+    private KeystoneAPIExternalPort keystoneAPIExternalPort;
+
+    @Mock
+    private KeystonePasswordEncryptor keystonePasswordEncryptor;
+
+    @InjectMocks
+    private KeystoneTokenModule keystoneTokenModule;
+
+    @Test
+    @DisplayName("사용자 Keystone credential이 있으면 프로젝트 스코프 토큰을 직접 발급한다.")
+    void givenUserCredentials_whenIssueScopedTokenByUserCredentials_thenReturnScopedToken() {
+        // given
+        String userId = "owner-id";
+        String projectId = "project-id";
+        UserDbExtraEntity user = createUser(userId);
+        KeystoneToken scopedToken = KeystoneToken.builder().token("scoped-token").build();
+        given(userRepositoryPort.findUserDetailById(userId)).willReturn(Optional.of(user));
+        given(keystonePasswordEncryptor.decrypt("encrypted-password")).willReturn("plain-password");
+        given(keystoneAPIExternalPort.getScopedTokenByPassword(
+                org.mockito.ArgumentMatchers.eq(projectId),
+                org.mockito.ArgumentMatchers.any(KeystonePasswordLoginRequest.class)
+        )).willReturn(scopedToken);
+
+        // when
+        String result = keystoneTokenModule.issueScopedTokenByUserCredentials(userId, projectId);
+
+        // then
+        assertThat(result).isEqualTo("scoped-token");
+        ArgumentCaptor<KeystonePasswordLoginRequest> requestCaptor =
+                ArgumentCaptor.forClass(KeystonePasswordLoginRequest.class);
+        then(keystoneAPIExternalPort).should()
+                .getScopedTokenByPassword(org.mockito.ArgumentMatchers.eq(projectId), requestCaptor.capture());
+        assertThat(requestCaptor.getValue().username()).isEqualTo("owner");
+    }
+
+    @Test
+    @DisplayName("Keystone credential이 없으면 작업용 토큰을 발급하지 않는다.")
+    void givenMissingCredentials_whenIssueScopedTokenByUserCredentials_thenThrowAuthServiceException() {
+        // given
+        String userId = "owner-id";
+        UserDbExtraEntity user = UserDbExtraEntity.builder()
+                .userId(userId)
+                .build();
+        given(userRepositoryPort.findUserDetailById(userId)).willReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> keystoneTokenModule.issueScopedTokenByUserCredentials(userId, "project-id"))
+                .isInstanceOf(AuthServiceException.class);
+    }
+
+    @Test
+    @DisplayName("작업용 토큰 폐기에 실패해도 호출자는 예외를 받지 않는다.")
+    void givenRevokeFailure_whenRevokeTokenQuietly_thenDoesNotThrowException() {
+        // given
+        willThrow(new RuntimeException("revoke failed"))
+                .given(keystoneAPIExternalPort)
+                .revokeToken("scoped-token");
+
+        // when & then
+        assertThatCode(() -> keystoneTokenModule.revokeTokenQuietly("scoped-token"))
+                .doesNotThrowAnyException();
+    }
+
+    private UserDbExtraEntity createUser(String userId) {
+        return UserDbExtraEntity.builder()
+                .userId(userId)
+                .keystoneUsername("owner")
+                .keystonePassword("encrypted-password")
+                .build();
+    }
+}


### PR DESCRIPTION
## 📌 변경 요약 (Summary)

> 이 PR에서 무엇을 변경했는지 간단히 설명해주세요.

- 토큰발급 프로세스에서 잔류하던 Redis 미참조 문제를 수정했습니다.
- 관리자가 프로젝트 등록 승인 시 내부로직 에러로 인해 OpenStack 정합성 훼손 및 등록실패 문제를 해결하였습니다.

---

## 🔗 관련 이슈 (Related Issue)

> 이 PR과 관련된 이슈를 작성해주세요.

Closes #24 

---

## 🛠 작업 내용 / 작업 순서 (Implementation Details)

> 이번 작업에서 수행한 내용이나 작업 순서를 작성해주세요.

1. 변경된 Redis 기반 로그인 세션 처리 플로우 확인
2. `KeystoneTokenModule` 추가 및 기존 레거시 코드 대체
3. 프로젝트 생성과정에서 발생하는 토큰발행문제 해결 확인
4. 프로젝트 생성 간 실패시 실행되는 정합성 복구로직 내 발생하는 토큰발행문제 해결 확인

---

## ✨ 주요 변경 사항 (Key Changes)

- `KeystoneTokenModule`을 새롭게 추가하여, 토큰발행 시 처리과정에 대한 처리를 `AuthModule`에서 분리
ㄴ 따라서 토큰을 생성할 수 있는 경로는 기존 레거시를 제외하면 크게 2가지로 정리됩니다:
  1. 내부 비즈니스 로직 상 제 3의 사용자에 대한 제어토큰이 일회성으로 필요한 경우: KeystoneTokenModule을 통해 토큰발급/사용 후 즉시파기
  2. 외부 API 엔드포인트를 통해 특정 사용자가 계정제어 요청을 하는 경우: SessionModule을 통해 세션을 관리

---

## 🧪 테스트 결과 (Test Results)

### 테스트 환경

- 로컬 Spring Boot 애플리케이션: `http://127.0.0.1:8080`
- 테스트 DB: `aolda-test-db` MariaDB 컨테이너
- 테스트 Redis: `aolda-test-redis` Redis 컨테이너
- OpenStack 테스트 환경 연동
- 인증 방식: Keycloak 로그인 미사용, Redis에 테스트용 `SessionData`를 직접 생성하고 `acc-session-id` 쿠키로 API 호출

### 테스트 방법

1. 전체 자동 테스트 실행
   - `./gradlew test`
   - 결과: `BUILD SUCCESSFUL`

2. 테스트 환경 기동 확인
   - Spring Boot 애플리케이션 `bootRun` 실행
   - `/actuator/health` 호출로 `UP` 확인
   - DB, Redis, OpenStack 초기 연결 로그 확인

3. 프로젝트 승인 요청 테스트 데이터 생성
   - 테스트 DB에 `PENDING` 상태의 프로젝트 생성 요청 삽입
   - Redis에 테스트용 세션 생성
   - 세션의 `keystoneUserId`는 credential이 존재하는 테스트 사용자로 설정

4. 실제 프로젝트 승인 API 호출
   - `POST /api/v1/admin/projects/request`
   - `Cookie: acc-session-id={test-session-id}`
   - 요청 상태: `APPROVED`

5. 성공 응답 확인
   - `requested=1`
   - `acknowledged=1`
   - `applied=1`
   - 응답 내 `projectId` 반환 확인

6. OpenStack 실제 생성 결과 확인
   - Keystone project 조회 `200`
   - Neutron network 1개 생성 확인
   - Neutron subnet 1개 생성 확인
   - Neutron router 1개 생성 확인
   - DB `project_requests.status=APPROVED` 확인
   - DB `projects`에 생성된 projectId 저장 확인

7. 테스트 리소스 정리 검증
   - router interface 제거
   - router 삭제
   - subnet 삭제
   - network 삭제
   - Keystone project 삭제
   - DB `projects`, `project_requests`, `outbox_events` 테스트 데이터 삭제
   - Redis 테스트 세션 삭제
   - 최종 잔여물 0건 확인

### 테스트 결과

- [x] 정상 동작 확인
- [x] 예외 상황 테스트
- [x] 기존 기능 영향 없음

검증 결과 요약:

```text
./gradlew test: BUILD SUCCESSFUL

프로젝트 승인 API:
requested=1
acknowledged=1
applied=1

OpenStack 생성 확인:
keystone_project_get_status=200
neutron.networks=1
neutron.subnets=1
neutron.routers=1

정리 후 확인:
neutron.networks=0
neutron.subnets=0
neutron.routers=0
keystone_project_get_status=404
db_projects=0
db_requests=0
db_outbox=0
redis_session_exists=0
```