### PR TITLE
[Fix] 프로젝트 단건요청 시 projectType이 null로 응답되는 문제 해결 #1

### DIFF
--- a/src/main/java/com/acc/local/dto/project/CreateProjectRequest.java
+++ b/src/main/java/com/acc/local/dto/project/CreateProjectRequest.java
@@ -1,5 +1,6 @@
 package com.acc.local.dto.project;
 
+import com.acc.local.domain.enums.project.ProjectRequestType;
 import com.acc.local.dto.project.quota.ProjectQuotaRequest;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -11,6 +12,9 @@ public record CreateProjectRequest(
         @Schema(description = "프로젝트 설명", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         String projectDescription,
 
+        @Schema(description = "프로젝트 유형", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        ProjectRequestType projectType,
+
 		@Schema(description = "프로젝트 가용량", requiredMode = Schema.RequiredMode.REQUIRED)
         ProjectQuotaRequest quota,
 
@@ -21,6 +25,7 @@ public record CreateProjectRequest(
         return ProjectCreateDto.builder()
                 .projectName(projectName)
                 .projectDescription(projectDescription)
+                .projectType(projectType)
                 .quota(quota)
                 .projectOwnerId(projectOwnerId)
                 .build();

--- a/src/main/java/com/acc/local/dto/project/GetProjectResponse.java
+++ b/src/main/java/com/acc/local/dto/project/GetProjectResponse.java
@@ -23,12 +23,17 @@ public record GetProjectResponse(
     List<ProjectParticipantDto> participants
 ) {
     public static GetProjectResponse from(ProjectServiceDto project) {
+        ProjectRequestType projectType = project.projectType();
+        if (projectType == null) {
+            projectType = ProjectRequestType.ETC;
+        }
+
         return GetProjectResponse.builder()
             .projectId(project.projectId())
             .projectName(project.projectName())
             .description(project.description())
             .isActive(project.isActive())
-            .projectType(project.projectType())
+            .projectType(projectType)
             .ownerKeystoneId(project.ownerKeystoneId())
             .createdAt(project.createdAt())
             .status(project.status())

--- a/src/main/java/com/acc/local/dto/project/ProjectCreateDto.java
+++ b/src/main/java/com/acc/local/dto/project/ProjectCreateDto.java
@@ -1,13 +1,15 @@
 package com.acc.local.dto.project;
 
+import com.acc.local.domain.enums.project.ProjectRequestType;
 import com.acc.local.dto.project.quota.ProjectQuotaRequest;
-import io.swagger.v3.oas.annotations.media.Schema;
+
 import lombok.Builder;
 
 @Builder
 public record ProjectCreateDto(
         String projectName,
         String projectDescription,
+        ProjectRequestType projectType,
         ProjectQuotaRequest quota,
         String projectOwnerId
 ) {

--- a/src/main/java/com/acc/local/dto/project/ProjectRequestDto.java
+++ b/src/main/java/com/acc/local/dto/project/ProjectRequestDto.java
@@ -42,6 +42,7 @@ public record ProjectRequestDto(
 				.projectOwnerId(requestUserId)
 				.projectDescription(getProjectDescriptionMessage(projectRequestId, approvedUserId))
 				.projectName(projectName)
+				.projectType(projectType)
 				.quota(ProjectQuotaRequest.from(projectBrief))
 				.build();
     }

--- a/src/main/java/com/acc/local/service/modules/auth/ProjectModule.java
+++ b/src/main/java/com/acc/local/service/modules/auth/ProjectModule.java
@@ -22,6 +22,7 @@ import com.acc.global.exception.auth.KeystoneException;
 import com.acc.global.exception.project.ProjectErrorCode;
 import com.acc.global.exception.project.ProjectServiceException;
 import com.acc.local.domain.enums.project.ProjectRequestStatus;
+import com.acc.local.domain.enums.project.ProjectRequestType;
 import com.acc.local.domain.enums.project.ProjectRole;
 import com.acc.local.dto.auth.UserKeystoneDto;
 import com.acc.local.dto.project.quota.ProjectComputeQuotaDto;
@@ -289,7 +290,7 @@ public class ProjectModule {
 			.quotaVRamMB((long)request.quota().vRam())
 			.quotaStorageGB((long)request.quota().storage())
 			.quotaInstanceCount((long)request.quota().instance())
-			// .projectType()
+			.projectType(request.projectType() == null ? ProjectRequestType.ETC : request.projectType())
 			.build();
 		projectRepositoryPort.save(aoldaProject);
 

--- a/src/test/java/com/acc/local/dto/project/GetProjectResponseTest.java
+++ b/src/test/java/com/acc/local/dto/project/GetProjectResponseTest.java
@@ -1,0 +1,35 @@
+package com.acc.local.dto.project;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.acc.local.domain.enums.project.ProjectRequestType;
+import org.junit.jupiter.api.Test;
+
+class GetProjectResponseTest {
+
+	@Test
+	void fromDefaultsNullProjectTypeToEtc() {
+		ProjectServiceDto project = ProjectServiceDto.builder()
+			.projectId("project-id")
+			.projectName("project-name")
+			.projectType(null)
+			.build();
+
+		GetProjectResponse response = GetProjectResponse.from(project);
+
+		assertThat(response.projectType()).isEqualTo(ProjectRequestType.ETC);
+	}
+
+	@Test
+	void fromKeepsExistingProjectType() {
+		ProjectServiceDto project = ProjectServiceDto.builder()
+			.projectId("project-id")
+			.projectName("project-name")
+			.projectType(ProjectRequestType.CAPSTONE_DESIGN)
+			.build();
+
+		GetProjectResponse response = GetProjectResponse.from(project);
+
+		assertThat(response.projectType()).isEqualTo(ProjectRequestType.CAPSTONE_DESIGN);
+	}
+}


### PR DESCRIPTION
## 📌 변경 요약 (Summary)

> 이 PR에서 무엇을 변경했는지 간단히 설명해주세요.

- 프로젝트 요청 승인/생성 경로에서 누락되던 `projectType` 전달 및 저장 로직을 추가했습니다.
- 프로젝트 단건 조회 응답 생성 시 기존 데이터의 `projectType`이 null이어도 `ETC`로 응답되도록 방어 로직을 추가했습니다.

---

## 🔗 관련 이슈 (Related Issue)

> 이 PR과 관련된 이슈를 작성해주세요.

Closes #1

---

## 🛠 작업 내용 / 작업 순서 (Implementation Details)

> 이번 작업에서 수행한 내용이나 작업 순서를 작성해주세요.

1. 이슈 #1 본문 및 재현 댓글 확인
2. `GetProjectResponse.from()`에 `projectType = null`인 DTO 입력 시 null 응답이 생성되는 증상 재현
3. 프로젝트 승인 요청의 `projectType`이 `ProjectCreateDto`로 전달되지 않는 경로 확인
4. `ProjectCreateDto`에 `projectType` 추가 및 `ProjectRequestDto.toProjectCreateDto()` 매핑 보강
5. `ProjectModule.createProject()`에서 `ProjectEntity.projectType` 저장 처리 추가
6. 관리자 직접 생성 등 타입이 없는 경로는 `ProjectRequestType.ETC`로 기본 저장되도록 보강
7. 단건 조회 응답 `GetProjectResponse.from()`에서 null 타입을 `ETC`로 보정
8. DTO 단위 테스트 추가 및 실제 API 응답 확인

---

## ✨ 주요 변경 사항 (Key Changes)

- `ProjectCreateDto`에 `ProjectRequestType projectType` 필드를 추가했습니다.
- 프로젝트 요청 승인 시 `ProjectRequestDto.projectType()`이 생성 DTO까지 전달되도록 수정했습니다.
- 프로젝트 생성 시 DB `projects.project_type`에 타입이 저장되도록 수정했습니다.
- 저장할 타입이 없는 경우 `ProjectRequestType.ETC`를 기본값으로 사용하여 신규 데이터의 null 저장을 방지했습니다.
- 기존 DB 데이터처럼 `projectType`이 null인 경우에도 단건 조회 응답에서는 `PROJECT_REQUEST_TYPE/ETC`로 내려가도록 `GetProjectResponse`를 보강했습니다.
- `GetProjectResponseTest`를 추가해 null 타입 기본값 처리와 기존 타입 유지 동작을 검증하도록 했습니다.

---

## 🧪 테스트 결과 (Test Results)

### 테스트 환경

- 로컬 Spring Boot 애플리케이션: `http://127.0.0.1:8080`
- 실행 방식: `screen` detached session에서 `java -jar build/libs/*.jar` 실행
- 테스트 DB: 기존 Docker `aolda-test-db` 컨테이너 (`127.0.0.1:13306`)
- 테스트 Redis: 기존 Docker `aolda-test-redis` 컨테이너 (`127.0.0.1:16379`)
- OpenStack 테스트 환경 연동 확인
- 인증 방식: `POST /api/v1/auth/login/general`로 테스트 계정 JWT 발급 후 `Authorization: Bearer` 헤더 사용

### 테스트 방법

1. 메인 코드 컴파일 및 bootJar 생성
   - `./gradlew compileJava`
   - `./gradlew bootJar`
   - 결과: `BUILD SUCCESSFUL`

2. 로컬 애플리케이션 백그라운드 실행
   - `screen -dmS aolda-issue1-app ... java -jar build/libs/*.jar`
   - `/actuator/health` 호출로 `UP` 확인
   - Swagger UI 접근 확인: `http://127.0.0.1:8080/swagger-ui.html` → HTTP 200

3. 테스트 인증 세팅
   - `POST /api/v1/auth/login/general` 호출
   - 결과: HTTP 200, 테스트용 JWT 발급 성공
   - `user_tokens` 활성 토큰 생성 확인

4. 테스트 대상 프로젝트 확인
   - 대상 projectId: `fdaa282089f94ecfb5f45e7224de2e91`
   - DB상 `project_type = NULL`인 기존 관리자 프로젝트로 확인

5. 실제 프로젝트 단건 조회 API 호출
   - `GET /api/v1/projects?projectId=fdaa282089f94ecfb5f45e7224de2e91`
   - `Authorization: Bearer {test-jwt}`

6. 성공 응답 확인
   - HTTP 200
   - 응답 내 `projectType`이 `null`이 아닌 `PROJECT_REQUEST_TYPE/ETC`로 반환됨 확인

7. 집중 테스트 실행 시도
   - `./gradlew test --tests com.acc.local.dto.project.GetProjectResponseTest`
   - 결과: `compileTestJava` 단계에서 기존 테스트 소스 컴파일 오류로 실패
   - 실패 원인: 이번 변경과 무관한 `KeystoneAPIExternalAdapterTest`, `VolumeSnapshotServiceAdapterTest`의 기존 타입 불일치 6건

### 테스트 결과

- [x] 정상 동작 확인
- [x] 예외 상황 테스트
- [x] 기존 기능 영향 없음 확인: 메인 코드 컴파일 성공 및 실제 단건 조회 API 응답 확인

검증 결과 요약:

```text
./gradlew compileJava: BUILD SUCCESSFUL
./gradlew bootJar: BUILD SUCCESSFUL

/actuator/health:
{"status":"UP"}

Swagger UI:
http://127.0.0.1:8080/swagger-ui.html -> HTTP 200

실제 API 호출:
GET /api/v1/projects?projectId=fdaa282089f94ecfb5f45e7224de2e91
HTTP 200
projectType=PROJECT_REQUEST_TYPE/ETC

집중 테스트 실행 시도:
./gradlew test --tests com.acc.local.dto.project.GetProjectResponseTest
결과: compileTestJava FAILED
사유: 기존 테스트 소스 타입 불일치 6건으로 테스트 컴파일 단계 실패
```