### PR TITLE
[Fix] project-scoped token이 말소되지 않는 문제 해결 #2

### DIFF
--- a/src/main/java/com/acc/local/domain/model/session/KeystoneTokens.java
+++ b/src/main/java/com/acc/local/domain/model/session/KeystoneTokens.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder(toBuilder = true)
@@ -14,5 +15,6 @@ import java.time.LocalDateTime;
 public class KeystoneTokens {
     private String unscopedToken;
     private String scopedToken;
+    private List<ProjectScopedToken> scopedTokens;
     private LocalDateTime expiresAt;
 }

--- a/src/main/java/com/acc/local/domain/model/session/ProjectScopedToken.java
+++ b/src/main/java/com/acc/local/domain/model/session/ProjectScopedToken.java
@@ -1,0 +1,18 @@
+package com.acc.local.domain.model.session;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProjectScopedToken {
+    private String projectId;
+    private String token;
+    private LocalDateTime expiresAt;
+}

--- a/src/main/java/com/acc/local/service/adapters/auth/AuthServiceAdapter.java
+++ b/src/main/java/com/acc/local/service/adapters/auth/AuthServiceAdapter.java
@@ -9,6 +9,7 @@ import com.acc.local.dto.auth.*;
 import com.acc.local.dto.project.ProjectServiceDto;
 import com.acc.local.dto.project.UserPermissionResponse;
 import com.acc.local.service.modules.auth.AuthModule;
+import com.acc.local.service.modules.auth.KeystoneTokenModule;
 import com.acc.local.service.modules.auth.ProjectModule;
 import com.acc.local.service.modules.auth.UserModule;
 import com.acc.local.service.ports.AuthServicePort;
@@ -26,6 +27,7 @@ public class AuthServiceAdapter implements AuthServicePort {
     private final AuthModule authModule;
     private final UserModule userModule;
     private final ProjectModule projectModule;
+    private final KeystoneTokenModule keystoneTokenModule;
 
     // keycloak 로그인 이후 redirect URL 엔드포인트에서 사용될 메서드
     @Override
@@ -131,7 +133,11 @@ public class AuthServiceAdapter implements AuthServicePort {
             ProjectServiceDto projectServiceDto = null;
             if (projectId != null && !projectId.isBlank()) {
                 String scopedToken = authModule.issueProjectScopeToken(projectId, userId);
-                projectServiceDto = projectModule.getProjectDetail(projectId, scopedToken);
+                try {
+                    projectServiceDto = projectModule.getProjectDetail(projectId, scopedToken);
+                } finally {
+                    keystoneTokenModule.revokeTokenQuietly(scopedToken);
+                }
             }
 
             return LoginedUserProfileResponse.builder()

--- a/src/main/java/com/acc/local/service/modules/keycloak/KeycloakAuthModule.java
+++ b/src/main/java/com/acc/local/service/modules/keycloak/KeycloakAuthModule.java
@@ -10,6 +10,7 @@ import com.acc.global.security.session.SessionConstants;
 import com.acc.local.domain.enums.UnivAccountType;
 import com.acc.local.domain.model.session.KeycloakTokens;
 import com.acc.local.domain.model.session.KeystoneTokens;
+import com.acc.local.domain.model.session.ProjectScopedToken;
 import com.acc.local.domain.model.session.SessionData;
 import com.acc.local.domain.model.session.UserInfo;
 import com.acc.local.dto.auth.KeycloakIdTokenClaims;
@@ -22,11 +23,14 @@ import com.acc.local.external.ports.KeycloakOidcExternalPort;
 import com.acc.local.external.ports.KeystoneAPIExternalPort;
 import com.acc.local.repository.ports.SessionRepositoryPort;
 import com.acc.local.service.modules.auth.AjouUnivModule;
+import com.acc.local.service.modules.auth.KeystoneTokenModule;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -60,6 +64,7 @@ public class KeycloakAuthModule {
     // 내부 모듈 의존
     private final KeycloakUserModule keycloakUserModule;
     private final AjouUnivModule ajouUnivModule;
+    private final KeystoneTokenModule keystoneTokenModule;
 
     // Token util
     private final KeycloakIdTokenParser keycloakIdTokenParser;
@@ -149,12 +154,13 @@ public class KeycloakAuthModule {
     }
 
     /**
-     * Keycloak 로그아웃 처리: Keycloak refresh_token 폐기 → Redis 세션 삭제.
+     * Keycloak 로그아웃 처리: Keycloak refresh_token/Keystone token 폐기 → Redis 세션 삭제.
      *
      * [처리 순서]
      *   1. sessionId로 Redis에서 SessionData 조회
      *   2. SessionData.keycloakTokens.refreshToken → Keycloak Token Revocation API 호출
-     *   3. Redis에서 세션 삭제
+     *   3. SessionData.keystoneTokens → Keystone Token Revocation API 호출
+     *   4. Redis에서 세션 삭제
      *
      * [Keycloak 폐기 실패 처리]
      *   Keycloak 서버가 일시 불가해도 로컬 세션은 반드시 삭제.
@@ -177,7 +183,30 @@ public class KeycloakAuthModule {
             log.warn("Keycloak 토큰 폐기 실패 (세션 삭제는 진행) - sessionId: {}", sessionId, e);
         }
 
+        revokeKeystoneTokens(sessionData.getKeystoneTokens());
+
         sessionRepositoryPort.deleteById(sessionId);
         log.info("Keycloak 로그아웃 완료 - sessionId: {}", sessionId);
+    }
+
+    private void revokeKeystoneTokens(KeystoneTokens keystoneTokens) {
+        if (keystoneTokens == null) {
+            return;
+        }
+
+        Set<String> tokens = new LinkedHashSet<>();
+        tokens.add(keystoneTokens.getUnscopedToken());
+        tokens.add(keystoneTokens.getScopedToken());
+        if (keystoneTokens.getScopedTokens() != null) {
+            for (ProjectScopedToken scopedToken : keystoneTokens.getScopedTokens()) {
+                if (scopedToken != null) {
+                    tokens.add(scopedToken.getToken());
+                }
+            }
+        }
+
+        for (String token : tokens) {
+            keystoneTokenModule.revokeTokenQuietly(token);
+        }
     }
 }

--- a/src/main/java/com/acc/local/service/modules/keypair/KeypairModule.java
+++ b/src/main/java/com/acc/local/service/modules/keypair/KeypairModule.java
@@ -20,6 +20,7 @@ import com.acc.local.repository.ports.ProjectRepositoryPort;
 import com.acc.local.repository.ports.UserRepositoryPort;
 import com.acc.local.repository.ports.ProjectParticipantRepositoryPort;
 import com.acc.local.service.modules.auth.AuthModule;
+import com.acc.local.service.modules.auth.KeystoneTokenModule;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -37,6 +38,7 @@ public class KeypairModule {
     private final ProjectRepositoryPort projectRepositoryPort;
     private final KeypairExternalPort keypairExternalPort;
     private final AuthModule authModule;
+    private final KeystoneTokenModule keystoneTokenModule;
     private final UserRepositoryPort userRepositoryPort;
 //    private final ProjectParticipantRepositoryPort projectParticipantRepositoryPort;
 
@@ -121,6 +123,8 @@ public class KeypairModule {
                         ex.getErrorCode().getMessage(), ex);
                 throw ex;  // Transaction Rollback
             }
+        } finally {
+            keystoneTokenModule.revokeTokenQuietly(ownerToken);
         }
     }
 }

--- a/src/main/java/com/acc/local/service/modules/session/SessionModule.java
+++ b/src/main/java/com/acc/local/service/modules/session/SessionModule.java
@@ -4,6 +4,7 @@ import com.acc.global.exception.session.SessionErrorCode;
 import com.acc.global.exception.session.SessionException;
 import com.acc.local.domain.model.session.KeycloakTokens;
 import com.acc.local.domain.model.session.KeystoneTokens;
+import com.acc.local.domain.model.session.ProjectScopedToken;
 import com.acc.local.domain.model.session.SessionData;
 import com.acc.local.dto.auth.KeystoneToken;
 import com.acc.local.external.dto.keycloak.KeycloakTokenResponse;
@@ -15,7 +16,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * 세션 기반 인증에서 토큰을 조회/갱신하는 모듈.
@@ -101,6 +104,7 @@ public class SessionModule {
 
     /**
      * 세션에서 Keystone scoped token을 발급한다 (캐시 없음, 매번 발급).
+     * 발급된 토큰은 로그아웃 시 폐기할 수 있도록 세션에 추적한다.
      *
      * [대체 대상] AuthModule.issueProjectScopeToken(String projectId, String userId)
      *   - 기존: userId → unscopedToken → getScopedToken(projectId, unscopedToken)
@@ -113,6 +117,7 @@ public class SessionModule {
     public String getKeystoneScopedToken(String sessionId, String projectId) {
         String unscopedToken = getKeystoneUnscopedToken(sessionId);
         KeystoneToken scopedToken = keystoneAPIExternalPort.getScopedToken(projectId, unscopedToken);
+        trackScopedToken(sessionId, projectId, unscopedToken, scopedToken);
         return scopedToken.token();
     }
 
@@ -142,7 +147,8 @@ public class SessionModule {
         KeystoneToken newToken = keystoneTokenModule.issueUnscopedTokenByUserCredentials(keystoneUserId);
 
         // 세션의 keystoneTokens 갱신
-        KeystoneTokens updatedKeystoneTokens = KeystoneTokens.builder()
+        KeystoneTokens currentTokens = sessionData.getKeystoneTokens();
+        KeystoneTokens updatedKeystoneTokens = (currentTokens == null ? KeystoneTokens.builder() : currentTokens.toBuilder())
                 .unscopedToken(newToken.token())
                 .expiresAt(newToken.expiresAt())
                 .build();
@@ -173,6 +179,31 @@ public class SessionModule {
 
         log.info("Keycloak access token 갱신 완료 - sessionId: {}", sessionId);
         return tokenResponse.accessToken();
+    }
+
+    private void trackScopedToken(String sessionId, String projectId, String unscopedToken, KeystoneToken scopedToken) {
+        SessionData sessionData = getSessionOrThrow(sessionId);
+        KeystoneTokens currentTokens = sessionData.getKeystoneTokens();
+        List<ProjectScopedToken> scopedTokens = new ArrayList<>();
+        if (currentTokens != null && currentTokens.getScopedTokens() != null) {
+            scopedTokens.addAll(currentTokens.getScopedTokens());
+        }
+        scopedTokens.add(ProjectScopedToken.builder()
+                .projectId(projectId)
+                .token(scopedToken.token())
+                .expiresAt(scopedToken.expiresAt())
+                .build());
+
+        KeystoneTokens updatedTokens = (currentTokens == null ? KeystoneTokens.builder() : currentTokens.toBuilder())
+                .unscopedToken(currentTokens != null && currentTokens.getUnscopedToken() != null
+                        ? currentTokens.getUnscopedToken()
+                        : unscopedToken)
+                .scopedToken(scopedToken.token())
+                .scopedTokens(scopedTokens)
+                .expiresAt(currentTokens != null ? currentTokens.getExpiresAt() : scopedToken.expiresAt())
+                .build();
+
+        sessionRepositoryPort.updateField(sessionId, "keystoneTokens", updatedTokens);
     }
 
     /**

--- a/src/test/java/com/acc/local/service/adapters/auth/AuthServiceAdapterTest.java
+++ b/src/test/java/com/acc/local/service/adapters/auth/AuthServiceAdapterTest.java
@@ -1,0 +1,61 @@
+package com.acc.local.service.adapters.auth;
+
+import com.acc.local.domain.model.auth.User;
+import com.acc.local.dto.project.ProjectServiceDto;
+import com.acc.local.service.modules.auth.AuthModule;
+import com.acc.local.service.modules.auth.KeystoneTokenModule;
+import com.acc.local.service.modules.auth.ProjectModule;
+import com.acc.local.service.modules.auth.UserModule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceAdapterTest {
+
+    @Mock
+    private AuthModule authModule;
+
+    @Mock
+    private UserModule userModule;
+
+    @Mock
+    private ProjectModule projectModule;
+
+    @Mock
+    private KeystoneTokenModule keystoneTokenModule;
+
+    @InjectMocks
+    private AuthServiceAdapter authServiceAdapter;
+
+    @Test
+    @DisplayName("레거시 프로필 조회에서 발급한 프로젝트 스코프 토큰은 사용 후 즉시 폐기한다.")
+    void givenProjectId_whenGetUserLoginedProfile_thenRevokeScopedToken() {
+        // given
+        String userId = "user-id";
+        String projectId = "project-id";
+        given(authModule.issueSystemAdminToken("ROOT_getUserLoginedProfile")).willReturn("admin-token");
+        given(userModule.getUserById(userId, "admin-token")).willReturn(User.builder()
+                .userId(userId)
+                .username("user")
+                .department("software")
+                .build());
+        given(authModule.issueProjectScopeToken(projectId, userId)).willReturn("scoped-token");
+        given(projectModule.getProjectDetail(projectId, "scoped-token")).willReturn(ProjectServiceDto.builder()
+                .projectId(projectId)
+                .build());
+
+        // when
+        authServiceAdapter.getUserLoginedProfile(userId, projectId);
+
+        // then
+        then(keystoneTokenModule).should().revokeTokenQuietly("scoped-token");
+        then(authModule).should().invalidateSystemAdminToken("admin-token");
+    }
+}

--- a/src/test/java/com/acc/local/service/modules/keycloak/KeycloakAuthModuleTest.java
+++ b/src/test/java/com/acc/local/service/modules/keycloak/KeycloakAuthModuleTest.java
@@ -1,0 +1,87 @@
+package com.acc.local.service.modules.keycloak;
+
+import com.acc.global.properties.KeycloakProperties;
+import com.acc.global.security.keycloak.KeycloakIdTokenParser;
+import com.acc.local.domain.model.session.KeycloakTokens;
+import com.acc.local.domain.model.session.KeystoneTokens;
+import com.acc.local.domain.model.session.ProjectScopedToken;
+import com.acc.local.domain.model.session.SessionData;
+import com.acc.local.external.ports.KeycloakOidcExternalPort;
+import com.acc.local.external.ports.KeystoneAPIExternalPort;
+import com.acc.local.repository.ports.SessionRepositoryPort;
+import com.acc.local.service.modules.auth.AjouUnivModule;
+import com.acc.local.service.modules.auth.KeystoneTokenModule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class KeycloakAuthModuleTest {
+
+    @Mock
+    private KeycloakOidcExternalPort keycloakOidcExternalPort;
+
+    @Mock
+    private KeystoneAPIExternalPort keystoneAPIExternalPort;
+
+    @Mock
+    private SessionRepositoryPort sessionRepositoryPort;
+
+    @Mock
+    private KeycloakUserModule keycloakUserModule;
+
+    @Mock
+    private AjouUnivModule ajouUnivModule;
+
+    @Mock
+    private KeystoneTokenModule keystoneTokenModule;
+
+    @Mock
+    private KeycloakIdTokenParser keycloakIdTokenParser;
+
+    @Mock
+    private KeycloakProperties keycloakProperties;
+
+    @InjectMocks
+    private KeycloakAuthModule keycloakAuthModule;
+
+    @Test
+    @DisplayName("로그아웃 시 Keycloak refresh token과 세션에 추적된 Keystone 토큰을 모두 폐기한다.")
+    void givenSessionTokens_whenLogout_thenRevokeKeycloakAndKeystoneTokens() {
+        // given
+        String sessionId = "session-id";
+        SessionData sessionData = SessionData.builder()
+                .keycloakTokens(KeycloakTokens.builder()
+                        .refreshToken("refresh-token")
+                        .build())
+                .keystoneTokens(KeystoneTokens.builder()
+                        .unscopedToken("unscoped-token")
+                        .scopedToken("latest-scoped-token")
+                        .scopedTokens(List.of(
+                                ProjectScopedToken.builder().projectId("project-1").token("scoped-token-1").build(),
+                                ProjectScopedToken.builder().projectId("project-2").token("scoped-token-2").build()))
+                        .build())
+                .build();
+        given(sessionRepositoryPort.findById(sessionId)).willReturn(Optional.of(sessionData));
+
+        // when
+        keycloakAuthModule.logout(sessionId);
+
+        // then
+        then(keycloakOidcExternalPort).should().revokeToken("refresh-token");
+        then(keystoneTokenModule).should().revokeTokenQuietly("unscoped-token");
+        then(keystoneTokenModule).should().revokeTokenQuietly("latest-scoped-token");
+        then(keystoneTokenModule).should().revokeTokenQuietly("scoped-token-1");
+        then(keystoneTokenModule).should().revokeTokenQuietly("scoped-token-2");
+        then(sessionRepositoryPort).should().deleteById(sessionId);
+    }
+}

--- a/src/test/java/com/acc/local/service/modules/keypair/KeypairModuleTest.java
+++ b/src/test/java/com/acc/local/service/modules/keypair/KeypairModuleTest.java
@@ -1,0 +1,74 @@
+package com.acc.local.service.modules.keypair;
+
+import com.acc.local.entity.KeypairEntity;
+import com.acc.local.entity.ProjectEntity;
+import com.acc.local.entity.UserDbExtraEntity;
+import com.acc.local.external.ports.KeypairExternalPort;
+import com.acc.local.repository.ports.KeypairRepositoryPort;
+import com.acc.local.repository.ports.ProjectRepositoryPort;
+import com.acc.local.repository.ports.UserRepositoryPort;
+import com.acc.local.service.modules.auth.AuthModule;
+import com.acc.local.service.modules.auth.KeystoneTokenModule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class KeypairModuleTest {
+
+    @Mock
+    private KeypairRepositoryPort keypairRepositoryPort;
+
+    @Mock
+    private ProjectRepositoryPort projectRepositoryPort;
+
+    @Mock
+    private KeypairExternalPort keypairExternalPort;
+
+    @Mock
+    private AuthModule authModule;
+
+    @Mock
+    private KeystoneTokenModule keystoneTokenModule;
+
+    @Mock
+    private UserRepositoryPort userRepositoryPort;
+
+    @InjectMocks
+    private KeypairModule keypairModule;
+
+    @Test
+    @DisplayName("레거시 키페어 삭제에서 발급한 소유자 프로젝트 스코프 토큰은 사용 후 즉시 폐기한다.")
+    void givenKeypair_whenDeleteKeypair_thenRevokeOwnerScopedToken() {
+        // given
+        String keypairId = "keypair-id";
+        String projectId = "project-id";
+        UserDbExtraEntity owner = UserDbExtraEntity.builder()
+                .userId("owner-id")
+                .build();
+        KeypairEntity keypair = KeypairEntity.builder()
+                .keypairId(keypairId)
+                .keypairName("keypair-name")
+                .user(owner)
+                .project(ProjectEntity.builder().projectId(projectId).build())
+                .build();
+        given(keypairRepositoryPort.findById(any())).willReturn(Optional.of(keypair));
+        given(authModule.issueProjectScopeToken(projectId, "owner-id")).willReturn("owner-scoped-token");
+
+        // when
+        keypairModule.deleteKeypair(keypairId, "requester-id", projectId);
+
+        // then
+        then(keypairExternalPort).should().deleteKeypair("owner-scoped-token", "keypair-name");
+        then(keystoneTokenModule).should().revokeTokenQuietly("owner-scoped-token");
+    }
+}

--- a/src/test/java/com/acc/local/service/modules/session/SessionModuleTest.java
+++ b/src/test/java/com/acc/local/service/modules/session/SessionModuleTest.java
@@ -1,0 +1,153 @@
+package com.acc.local.service.modules.session;
+
+import com.acc.local.domain.model.session.KeystoneTokens;
+import com.acc.local.domain.model.session.ProjectScopedToken;
+import com.acc.local.domain.model.session.SessionData;
+import com.acc.local.dto.auth.KeystoneToken;
+import com.acc.local.external.ports.KeycloakOidcExternalPort;
+import com.acc.local.external.ports.KeystoneAPIExternalPort;
+import com.acc.local.repository.ports.SessionRepositoryPort;
+import com.acc.local.service.modules.auth.KeystoneTokenModule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class SessionModuleTest {
+
+    @Mock
+    private SessionRepositoryPort sessionRepositoryPort;
+
+    @Mock
+    private KeystoneAPIExternalPort keystoneAPIExternalPort;
+
+    @Mock
+    private KeycloakOidcExternalPort keycloakOidcExternalPort;
+
+    @Mock
+    private KeystoneTokenModule keystoneTokenModule;
+
+    @InjectMocks
+    private SessionModule sessionModule;
+
+    @Test
+    @DisplayName("프로젝트 스코프 토큰을 발급하면 로그아웃 폐기를 위해 세션에 추적한다.")
+    void givenSession_whenGetKeystoneScopedToken_thenTrackScopedTokenInSession() {
+        // given
+        String sessionId = "session-id";
+        String projectId = "project-id";
+        LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(30);
+        SessionData sessionData = SessionData.builder()
+                .keystoneTokens(KeystoneTokens.builder()
+                        .unscopedToken("unscoped-token")
+                        .expiresAt(expiresAt)
+                        .build())
+                .build();
+        KeystoneToken scopedToken = KeystoneToken.builder()
+                .token("scoped-token")
+                .expiresAt(LocalDateTime.now().plusMinutes(20))
+                .build();
+
+        given(sessionRepositoryPort.findById(sessionId)).willReturn(Optional.of(sessionData));
+        given(keystoneAPIExternalPort.getScopedToken(projectId, "unscoped-token")).willReturn(scopedToken);
+
+        // when
+        String result = sessionModule.getKeystoneScopedToken(sessionId, projectId);
+
+        // then
+        assertThat(result).isEqualTo("scoped-token");
+        ArgumentCaptor<KeystoneTokens> tokensCaptor = ArgumentCaptor.forClass(KeystoneTokens.class);
+        then(sessionRepositoryPort).should().updateField(eq(sessionId), eq("keystoneTokens"), tokensCaptor.capture());
+
+        KeystoneTokens updatedTokens = tokensCaptor.getValue();
+        assertThat(updatedTokens.getUnscopedToken()).isEqualTo("unscoped-token");
+        assertThat(updatedTokens.getScopedToken()).isEqualTo("scoped-token");
+        assertThat(updatedTokens.getScopedTokens()).hasSize(1);
+        assertThat(updatedTokens.getScopedTokens().get(0).getProjectId()).isEqualTo(projectId);
+        assertThat(updatedTokens.getScopedTokens().get(0).getToken()).isEqualTo("scoped-token");
+        assertThat(updatedTokens.getExpiresAt()).isEqualTo(expiresAt);
+    }
+
+    @Test
+    @DisplayName("기존 프로젝트 스코프 토큰 추적 목록이 있으면 새 토큰을 누적한다.")
+    void givenTrackedScopedToken_whenGetKeystoneScopedToken_thenAppendScopedToken() {
+        // given
+        String sessionId = "session-id";
+        String projectId = "project-2";
+        SessionData sessionData = SessionData.builder()
+                .keystoneTokens(KeystoneTokens.builder()
+                        .unscopedToken("unscoped-token")
+                        .scopedTokens(java.util.List.of(
+                                ProjectScopedToken.builder()
+                                        .projectId("project-1")
+                                        .token("scoped-token-1")
+                                        .build()))
+                        .expiresAt(LocalDateTime.now().plusMinutes(30))
+                        .build())
+                .build();
+        KeystoneToken scopedToken = KeystoneToken.builder().token("scoped-token-2").build();
+
+        given(sessionRepositoryPort.findById(sessionId)).willReturn(Optional.of(sessionData));
+        given(keystoneAPIExternalPort.getScopedToken(projectId, "unscoped-token")).willReturn(scopedToken);
+
+        // when
+        sessionModule.getKeystoneScopedToken(sessionId, projectId);
+
+        // then
+        ArgumentCaptor<KeystoneTokens> tokensCaptor = ArgumentCaptor.forClass(KeystoneTokens.class);
+        then(sessionRepositoryPort).should().updateField(eq(sessionId), eq("keystoneTokens"), tokensCaptor.capture());
+        assertThat(tokensCaptor.getValue().getScopedTokens())
+                .extracting("token")
+                .containsExactly("scoped-token-1", "scoped-token-2");
+    }
+
+    @Test
+    @DisplayName("Keystone unscoped token을 재발급해도 기존 프로젝트 스코프 토큰 추적 목록은 유지한다.")
+    void givenTrackedScopedToken_whenReissueKeystoneUnscopedToken_thenPreserveScopedTokens() {
+        // given
+        String sessionId = "session-id";
+        SessionData sessionData = SessionData.builder()
+                .keystoneUserId("user-id")
+                .keystoneTokens(KeystoneTokens.builder()
+                        .unscopedToken("expired-unscoped-token")
+                        .scopedTokens(java.util.List.of(
+                                ProjectScopedToken.builder()
+                                        .projectId("project-1")
+                                        .token("scoped-token-1")
+                                        .build()))
+                        .expiresAt(LocalDateTime.now().minusMinutes(1))
+                        .build())
+                .build();
+        KeystoneToken newUnscopedToken = KeystoneToken.builder()
+                .token("new-unscoped-token")
+                .expiresAt(LocalDateTime.now().plusMinutes(30))
+                .build();
+
+        given(sessionRepositoryPort.findById(sessionId)).willReturn(Optional.of(sessionData));
+        given(keystoneTokenModule.issueUnscopedTokenByUserCredentials("user-id")).willReturn(newUnscopedToken);
+
+        // when
+        String result = sessionModule.getKeystoneUnscopedToken(sessionId);
+
+        // then
+        assertThat(result).isEqualTo("new-unscoped-token");
+        ArgumentCaptor<KeystoneTokens> tokensCaptor = ArgumentCaptor.forClass(KeystoneTokens.class);
+        then(sessionRepositoryPort).should().updateField(eq(sessionId), eq("keystoneTokens"), tokensCaptor.capture());
+        assertThat(tokensCaptor.getValue().getUnscopedToken()).isEqualTo("new-unscoped-token");
+        assertThat(tokensCaptor.getValue().getScopedTokens())
+                .extracting("token")
+                .containsExactly("scoped-token-1");
+    }
+}


### PR DESCRIPTION
## 📌 변경 요약 (Summary)

> 이 PR에서 무엇을 변경했는지 간단히 설명해주세요.

- 세션 기반 Keystone project-scoped token 발급 시 Redis 세션에 토큰을 추적하도록 수정했습니다.
- Keycloak 로그아웃 시 세션에 남아있는 Keystone unscoped/scoped token을 함께 폐기하도록 보강했습니다.
- legacy `AuthModule.issueProjectScopeToken()` 사용 경로 중 프로필 조회/키페어 삭제에서 발급 토큰을 사용 후 즉시 폐기하도록 수정했습니다.

---

## 🔗 관련 이슈 (Related Issue)

> 이 PR과 관련된 이슈를 작성해주세요.

Closes #2

---

## 🛠 작업 내용 / 작업 순서 (Implementation Details)

> 이번 작업에서 수행한 내용이나 작업 순서를 작성해주세요.

1. `SessionModule.getKeystoneScopedToken()`의 scoped token 발급 흐름 확인
2. Redis `SessionData.keystoneTokens`에 project-scoped token 추적 목록 추가
3. Keystone unscoped token 재발급 시 기존 scoped token 추적 목록 보존
4. Keycloak 로그아웃 시 Keycloak refresh token과 Keystone token 폐기 순서 보강
5. legacy 프로필 조회/키페어 삭제 경로의 scoped token 즉시 폐기 처리
6. 세션/로그아웃/legacy 경로 단위 테스트 추가
7. 로컬 앱과 Docker Redis/DB 기반 실제 세션 추적 및 로그아웃 삭제 검증

---

## ✨ 주요 변경 사항 (Key Changes)

- `ProjectScopedToken` 모델을 추가하여 Redis 세션에 발급된 project-scoped token 목록을 추적합니다.
- `KeystoneTokens.scopedTokens`를 통해 한 세션에서 여러 번 발급된 scoped token을 로그아웃 시 모두 폐기할 수 있게 했습니다.
- `KeycloakAuthModule.logout()`에서 세션 삭제 전 Keystone unscoped token, 최신 scoped token, 누적 scoped token을 중복 제거 후 `revokeTokenQuietly()`로 폐기합니다.
- `AuthServiceAdapter.getUserLoginedProfile()`과 `KeypairModule.deleteKeypair()`의 legacy scoped token은 `finally`에서 즉시 폐기합니다.

---

## 🧪 테스트 결과 (Test Results)

### 테스트 환경

- 로컬 Spring Boot 애플리케이션: `http://127.0.0.1:8080`
- 테스트 DB: MariaDB 컨테이너 (`127.0.0.1:13306`)
- 테스트 Redis: Redis 컨테이너 (`127.0.0.1:16379`)
- OpenStack 테스트 환경 연동
- 인증 방식: Redis에 테스트용 `SessionData`를 직접 생성하고 `acc-session-id` 쿠키로 API 호출

### 테스트 방법

1. 수정 범위 집중 자동 테스트 실행
   - `./gradlew test --tests com.acc.local.service.modules.session.SessionModuleTest --tests com.acc.local.service.modules.keycloak.KeycloakAuthModuleTest --tests com.acc.local.service.adapters.auth.AuthServiceAdapterTest --tests com.acc.local.service.modules.keypair.KeypairModuleTest`
   - 결과: `BUILD SUCCESSFUL`

2. 전체 자동 테스트 실행
   - `./gradlew test`
   - 결과: `BUILD SUCCESSFUL`

3. 테스트 환경 기동 확인
   - Spring Boot 애플리케이션 `bootRun` 실행
   - `/actuator/health` 호출로 `UP` 확인
   - DB, Redis, OpenStack Keystone/Nova 연결 가능 상태 확인

4. 실제 프로젝트 상세 API 호출로 scoped token 추적 확인
   - Redis에 유효한 unscoped token을 가진 테스트 세션 생성
   - `GET /api/v1/projects?projectId=fdaa282089f94ecfb5f45e7224de2e91`
   - `Cookie: acc-session-id={test-session-id}`
   - 결과: `HTTP 200`
   - Redis `keystoneTokens.scopedToken` 존재 확인
   - Redis `keystoneTokens.scopedTokens_count=1` 확인
   - Redis `tracked_project=fdaa282089f94ecfb5f45e7224de2e91` 확인

5. 실제 로그아웃 API 호출로 tracked token 포함 세션 삭제 확인
   - `DELETE /api/v1/auth/keycloak/logout`
   - `Cookie: acc-session-id={test-session-id}`
   - 결과: `HTTP 200`
   - Redis 세션 삭제 확인: `exists_after=0`

6. 키페어 도메인 실제 경로 확인
   - `POST /api/v1/keypairs?projectId=fdaa282089f94ecfb5f45e7224de2e91`
   - Keystone scoped token 발급 성공 확인
   - Nova keypair 생성 단계에서 OpenStack 권한 문제로 `HTTP 403` 반환 확인
   - 결과 코드: `ACC-KEYPAIR-EXTERNAL-FORBIDDEN`
   - 삭제 성공 케이스는 환경 권한 제약으로 실제 API 완료 검증 불가, 단위 테스트로 `finally` revoke 호출 검증

### 테스트 결과

- [x] 정상 동작 확인
- [x] 예외 상황 테스트
- [x] 기존 기능 영향 없음

검증 결과 요약:

```text
Focused tests: BUILD SUCCESSFUL
./gradlew test: BUILD SUCCESSFUL

Spring Boot health:
status=UP

Project detail API:
status=200
scopedToken_present=true
scopedTokens_count=1
tracked_project=fdaa282089f94ecfb5f45e7224de2e91

Logout API:
status=200
redis_session_exists_after=0

Keypair create API:
keystone_scoped_token_issue=success
nova_keypair_create_status=403
error_code=ACC-KEYPAIR-EXTERNAL-FORBIDDEN
```
