### PR TITLE
[Fix] 프로젝트 쿼터 응답 DTO가 통일되지 않는 문제 해결 #27

### DIFF
--- a/src/main/java/com/acc/local/controller/docs/AdminProjectDocs.java
+++ b/src/main/java/com/acc/local/controller/docs/AdminProjectDocs.java
@@ -38,7 +38,49 @@ public interface AdminProjectDocs {
 		description = "전체 프로젝트 목록을 조회합니다."
 	)
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "프로젝트 목록 조회 성공", content = @Content()),
+		@ApiResponse(
+			responseCode = "200",
+			description = "프로젝트 목록 조회 성공",
+			content = @Content(
+				mediaType = "application/json",
+				schema = @Schema(implementation = PageResponse.class),
+				examples = {
+					@ExampleObject(
+						name = "관리자 프로젝트 목록 조회",
+						value = """
+							{
+							  "contents": [
+							    {
+							      "projectId": "0cc61cc8ed964714a06a42afa92c1dc6",
+							      "projectName": "admin",
+							      "projectType": "PROJECT_REQUEST_TYPE/ETC",
+							      "createdBy": null,
+							      "createdAt": "1900-01-01T00:00",
+							      "status": "APPROVED",
+							      "quota": {
+							        "instance": { "available": 10, "used": 2 },
+							        "core": { "available": 20, "used": 2 },
+							        "ram": { "available": 51200, "used": 1024 },
+							        "volume": {
+							          "count": { "available": 10, "used": 2 },
+							          "size": { "available": 1000, "used": 30 }
+							        }
+							      },
+							      "participants": [],
+							      "rejectReason": null
+							    }
+							  ],
+							  "first": true,
+							  "last": false,
+							  "size": 1,
+							  "nextMarker": "0cc61cc8ed964714a06a42afa92c1dc6",
+							  "prevMarker": null
+							}
+							"""
+					)
+				}
+			)
+		),
 		@ApiResponse(responseCode = "400", description = "잘못된 요청 - 요청 파라미터 오류", content = @Content()),
 		@ApiResponse(responseCode = "401", description = "인증 실패 - 유효하지 않은 토큰", content = @Content()),
 		@ApiResponse(responseCode = "403", description = "권한 없음 - API 접근 권한이 없음", content = @Content()),
@@ -94,7 +136,50 @@ public interface AdminProjectDocs {
 		description = "모든 프로젝트 생성요청 목록을 조회합니다."
 	)
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "생성요청 목록 조회 성공", content = @Content()),
+		@ApiResponse(
+			responseCode = "200",
+			description = "생성요청 목록 조회 성공",
+			content = @Content(
+				mediaType = "application/json",
+				schema = @Schema(implementation = PageResponse.class),
+				examples = {
+					@ExampleObject(
+						name = "관리자 프로젝트 생성요청 목록 조회",
+						value = """
+							{
+							  "contents": [
+							    {
+							      "projectRequestId": "ad1af0b6-0ac7-4005-95b9-9b0a325f00a9",
+							      "projectName": "캡스톤 프로젝트 요청",
+							      "projectType": "PROJECT_REQUEST_TYPE/CAPSTONE_DESIGN",
+							      "createdBy": {
+							        "userId": "f52f7447cba1476da8fa281bf6fff220",
+							        "userName": "Waccounttest_1"
+							      },
+							      "createdAt": "2025-11-24T02:04:36.473286",
+							      "status": "PENDING",
+							      "quota": {
+							        "instance": { "available": 10, "used": 0 },
+							        "core": { "available": 8, "used": 0 },
+							        "ram": { "available": 32768, "used": 0 },
+							        "volume": {
+							          "count": { "available": 10, "used": 0 },
+							          "size": { "available": 1024, "used": 0 }
+							        }
+							      }
+							    }
+							  ],
+							  "first": true,
+							  "last": false,
+							  "size": 1,
+							  "nextMarker": "ad1af0b6-0ac7-4005-95b9-9b0a325f00a9",
+							  "prevMarker": null
+							}
+							"""
+					)
+				}
+			)
+		),
 		@ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content()),
 		@ApiResponse(responseCode = "401", description = "인증 실패 - 유효하지 않은 토큰", content = @Content()),
 		@ApiResponse(responseCode = "403", description = "권한 없음 - API 접근 권한이 없음", content = @Content()),

--- a/src/main/java/com/acc/local/controller/docs/ProjectDocs.java
+++ b/src/main/java/com/acc/local/controller/docs/ProjectDocs.java
@@ -44,8 +44,7 @@ public interface ProjectDocs {
 		summary = "프로젝트 목록 조회",
 		description = "로그인된 사용자가 접근권한을 가지고 있는 프로젝트들에 대한 목록을 조회합니다. \n"
 			+ "- keyword는 현재 프로젝트 제목만 입력 가능하며, 구현문제로 현재는 정확히 일치하는 경우에 대해서면 응답됩니다 \n"
-			+ "- 요청에 따라 필드명에 대한 응답명세가 통일되었습니다. FE 측에서 반영 부탁드립니다. \n"
-			+ "- 'projectBrief' 필드가 'quota' 필드로 변경될 예정입니다. 현 버전에서는 두 필드 모두 항상 같은 값을 담은 상태로 응답되나, 'quota'로 변경완료 시 말씀주시면 완전변경 하도록 하겠습니다"
+			+ "- 프로젝트 쿼터 정보는 quota 필드로 응답됩니다."
 	)
 	@ApiResponses(value = {
 		@ApiResponse(
@@ -56,228 +55,59 @@ public interface ProjectDocs {
 				examples = {
 					@ExampleObject(
 						name = "프로젝트 목록 조회",
-						value = "[\n"
-							+ "  {\n"
-							+ "    \"projectId\": \"0cc61cc8ed964714a06a42afa92c1dc6\",\n"
-							+ "    \"projectName\": \"admin\",\n"
-							+ "    \"projectType\": \"PROJECT_REQUEST_TYPE/ETC\",\n"
-							+ "    \"createdBy\": null,\n"
-							+ "    \"createdAt\": \"1900-01-01T00:00\",\n"
-							+ "    \"status\": \"APPROVED\",\n"
-							+ "    \"quota\": {\n"
-							+ "        \"instance\": {\n"
-							+ "          \"available\": 10,\n"
-							+ "          \"used\": 2\n"
-							+ "        },\n"
-							+ "        \"core\": {\n"
-							+ "          \"available\": 20,\n"
-							+ "          \"used\": 2\n"
-							+ "        },\n"
-							+ "        \"ram\": {\n"
-							+ "          \"available\": 51200,\n"
-							+ "          \"used\": 1024\n"
-							+ "        },\n"
-							+ "        \"volume\": {\n"
-							+ "          \"count\": {\n"
-							+ "            \"available\": 10,\n"
-							+ "            \"used\": 2\n"
-							+ "          },\n"
-							+ "          \"size\": {\n"
-							+ "            \"available\": 1000,\n"
-							+ "            \"used\": 30\n"
-							+ "          }\n"
-							+ "        }\n"
-							+ "      },"
-							+ "    \"participants\": [],\n"
-							+ "    \"rejectReason\": null\n"
-							+ "  },\n"
-							+ "  {\n"
-							+ "    \"projectId\": \"547b772d43684321991cbde58f06a264\",\n"
-							+ "    \"projectName\": \"ACCSwaggerProjectCreateTest\",\n"
-							+ "    \"projectType\": \"PROJECT_REQUEST_TYPE/ETC\",\n"
-							+ "    \"createdBy\": null,\n"
-							+ "    \"createdAt\": \"2025-11-26T17:59:53.229554\",\n"
-							+ "    \"status\": \"APPROVED\",\n"
-							+ "    \"projectBrief\": {\n"
-							+ "      \"vCpu\": 8,\n"
-							+ "      \"vRam\": 32,\n"
-							+ "      \"instance\": 10,\n"
-							+ "      \"storage\": 1000\n"
-							+ "    },\n"
-							+ "    \"participants\": [],\n"
-							+ "    \"rejectReason\": null\n"
-							+ "  },\n"
-							+ "  {\n"
-							+ "    \"projectId\": \"95282c49df5d47f68bb79bf4ad63a69b\",\n"
-							+ "    \"projectName\": \"AccTestProject\",\n"
-							+ "    \"projectType\": \"PROJECT_REQUEST_TYPE/ETC\",\n"
-							+ "    \"createdBy\": null,\n"
-							+ "    \"createdAt\": \"2025-11-26T17:59:53.232417\",\n"
-							+ "    \"status\": \"APPROVED\",\n"
-							+ "    \"quota\": {\n"
-							+ "        \"instance\": {\n"
-							+ "          \"available\": 10,\n"
-							+ "          \"used\": 2\n"
-							+ "        },\n"
-							+ "        \"core\": {\n"
-							+ "          \"available\": 20,\n"
-							+ "          \"used\": 2\n"
-							+ "        },\n"
-							+ "        \"ram\": {\n"
-							+ "          \"available\": 51200,\n"
-							+ "          \"used\": 1024\n"
-							+ "        },\n"
-							+ "        \"volume\": {\n"
-							+ "          \"count\": {\n"
-							+ "            \"available\": 10,\n"
-							+ "            \"used\": 2\n"
-							+ "          },\n"
-							+ "          \"size\": {\n"
-							+ "            \"available\": 1000,\n"
-							+ "            \"used\": 30\n"
-							+ "          }\n"
-							+ "        }\n"
-							+ "      },"
-							+ "    \"participants\": [],\n"
-							+ "    \"rejectReason\": null\n"
-							+ "  },\n"
-							+ "  {\n"
-							+ "    \"projectId\": null,\n"
-							+ "    \"projectName\": \"abcabcasefes\",\n"
-							+ "    \"projectType\": \"PROJECT_REQUEST_TYPE/CAPSTONE_DESIGN\",\n"
-							+ "    \"createdBy\": {\n"
-							+ "      \"userId\": \"de15e36af072460da2e39a74be3595b6\",\n"
-							+ "      \"userName\": \"Acc_test_Admin1\"\n"
-							+ "    },\n"
-							+ "    \"createdAt\": \"2025-11-24T02:00:31.440323\",\n"
-							+ "    \"status\": \"PENDING\",\n"
-							+ "    \"quota\": {\n"
-							+ "        \"instance\": {\n"
-							+ "          \"available\": 10,\n"
-							+ "          \"used\": 2\n"
-							+ "        },\n"
-							+ "        \"core\": {\n"
-							+ "          \"available\": 20,\n"
-							+ "          \"used\": 2\n"
-							+ "        },\n"
-							+ "        \"ram\": {\n"
-							+ "          \"available\": 51200,\n"
-							+ "          \"used\": 1024\n"
-							+ "        },\n"
-							+ "        \"volume\": {\n"
-							+ "          \"count\": {\n"
-							+ "            \"available\": 10,\n"
-							+ "            \"used\": 2\n"
-							+ "          },\n"
-							+ "          \"size\": {\n"
-							+ "            \"available\": 1000,\n"
-							+ "            \"used\": 30\n"
-							+ "          }\n"
-							+ "        }\n"
-							+ "      },"
-							+ "    \"participants\": [\n"
-							+ "      {\n"
-							+ "        \"userId\": \"de15e36af072460da2e39a74be3595b6\",\n"
-							+ "        \"userName\": \"Acc_test_Admin1\",\n"
-							+ "        \"userEmail\": null,\n"
-							+ "        \"userPhoneNumber\": null,\n"
-							+ "        \"role\": \"PROJECT_ADMIN\"\n"
-							+ "      }\n"
-							+ "    ],\n"
-							+ "    \"rejectReason\": null\n"
-							+ "  },\n"
-							+ "  {\n"
-							+ "    \"projectId\": null,\n"
-							+ "    \"projectName\": \"가나다라마바사\",\n"
-							+ "    \"projectType\": \"PROJECT_REQUEST_TYPE/MAJOR_LECTURE\",\n"
-							+ "    \"createdBy\": {\n"
-							+ "      \"userId\": \"de15e36af072460da2e39a74be3595b6\",\n"
-							+ "      \"userName\": \"Acc_test_Admin1\"\n"
-							+ "    },\n"
-							+ "    \"createdAt\": \"2025-11-25T02:14:58.849064\",\n"
-							+ "    \"status\": \"PENDING\",\n"
-							+ "    \"quota\": {\n"
-							+ "        \"instance\": {\n"
-							+ "          \"available\": 10,\n"
-							+ "          \"used\": 2\n"
-							+ "        },\n"
-							+ "        \"core\": {\n"
-							+ "          \"available\": 20,\n"
-							+ "          \"used\": 2\n"
-							+ "        },\n"
-							+ "        \"ram\": {\n"
-							+ "          \"available\": 51200,\n"
-							+ "          \"used\": 1024\n"
-							+ "        },\n"
-							+ "        \"volume\": {\n"
-							+ "          \"count\": {\n"
-							+ "            \"available\": 10,\n"
-							+ "            \"used\": 2\n"
-							+ "          },\n"
-							+ "          \"size\": {\n"
-							+ "            \"available\": 1000,\n"
-							+ "            \"used\": 30\n"
-							+ "          }\n"
-							+ "        }\n"
-							+ "      },"
-							+ "    \"participants\": [\n"
-							+ "      {\n"
-							+ "        \"userId\": \"de15e36af072460da2e39a74be3595b6\",\n"
-							+ "        \"userName\": \"Acc_test_Admin1\",\n"
-							+ "        \"userEmail\": null,\n"
-							+ "        \"userPhoneNumber\": null,\n"
-							+ "        \"role\": \"PROJECT_ADMIN\"\n"
-							+ "      }\n"
-							+ "    ],\n"
-							+ "    \"rejectReason\": null\n"
-							+ "  }\n"
-							+ "]"
-					),
-					@ExampleObject(
-						name = "프로젝트 상세정보 조회",
-						value = "{\n"
-							+ "  \"projectId\": \"a2b65bb6cbe14cf89b7b120480c92acf\",\n"
-							+ "  \"projectName\": \"AVC1awfwef24234\",\n"
-							+ "  \"description\": \"AVC124234\",\n"
-							+ "  \"isActive\": true,\n"
-							+ "  \"projectType\": null,\n"
-							+ "  \"ownerKeystoneId\": \"de15e36af072460da2e39a74be3595b6\",\n"
-							+ "  \"createdAt\": \"2025-11-25T02:06:04.158384\",\n"
-							+ "  \"status\": \"APPROVED\",\n"
-							+ "  \"quota\": {\n"
-							+ "      \"instance\": {\n"
-							+ "        \"available\": 10,\n"
-							+ "        \"used\": 2\n"
-							+ "      },\n"
-							+ "      \"core\": {\n"
-							+ "        \"available\": 20,\n"
-							+ "        \"used\": 2\n"
-							+ "      },\n"
-							+ "      \"ram\": {\n"
-							+ "        \"available\": 51200,\n"
-							+ "        \"used\": 1024\n"
-							+ "      },\n"
-							+ "      \"volume\": {\n"
-							+ "        \"count\": {\n"
-							+ "          \"available\": 10,\n"
-							+ "          \"used\": 2\n"
-							+ "        },\n"
-							+ "        \"size\": {\n"
-							+ "          \"available\": 1000,\n"
-							+ "          \"used\": 30\n"
-							+ "        }\n"
-							+ "      }\n"
-							+ "    },"
-							+ "  \"participants\": [\n"
-							+ "    {\n"
-							+ "      \"userId\": \"de15e36af072460da2e39a74be3595b6\",\n"
-							+ "      \"userName\": \"${SUPER_ADMIN_USER_NAME}\",\n"
-							+ "      \"userEmail\": null,\n"
-							+ "      \"userPhoneNumber\": \"010-0000-0000\",\n"
-							+ "      \"role\": \"PROJECT_ADMIN\"\n"
-							+ "    }\n"
-							+ "  ]\n"
-							+ "}"
+						value = """
+							[
+							  {
+							    "projectId": "0cc61cc8ed964714a06a42afa92c1dc6",
+							    "projectName": "admin",
+							    "projectType": "PROJECT_REQUEST_TYPE/ETC",
+							    "createdBy": null,
+							    "createdAt": "1900-01-01T00:00",
+							    "status": "APPROVED",
+							    "quota": {
+							      "instance": { "available": 10, "used": 2 },
+							      "core": { "available": 20, "used": 2 },
+							      "ram": { "available": 51200, "used": 1024 },
+							      "volume": {
+							        "count": { "available": 10, "used": 2 },
+							        "size": { "available": 1000, "used": 30 }
+							      }
+							    },
+							    "participants": [],
+							    "rejectReason": null
+							  },
+							  {
+							    "projectId": null,
+							    "projectName": "캡스톤 프로젝트 요청",
+							    "projectType": "PROJECT_REQUEST_TYPE/CAPSTONE_DESIGN",
+							    "createdBy": {
+							      "userId": "de15e36af072460da2e39a74be3595b6",
+							      "userName": "Acc_test_Admin1"
+							    },
+							    "createdAt": "2025-11-24T02:00:31.440323",
+							    "status": "PENDING",
+							    "quota": {
+							      "instance": { "available": 10, "used": 0 },
+							      "core": { "available": 8, "used": 0 },
+							      "ram": { "available": 32768, "used": 0 },
+							      "volume": {
+							        "count": { "available": 10, "used": 0 },
+							        "size": { "available": 1024, "used": 0 }
+							      }
+							    },
+							    "participants": [
+							      {
+							        "userId": "de15e36af072460da2e39a74be3595b6",
+							        "userName": "Acc_test_Admin1",
+							        "userEmail": null,
+							        "userPhoneNumber": null,
+							        "role": "PROJECT_ADMIN"
+							      }
+							    ],
+							    "rejectReason": null
+							  }
+							]
+							"""
 					)
 				},
 				schema = @Schema(oneOf = {ProjectResponse.class, List.class})
@@ -325,118 +155,67 @@ public interface ProjectDocs {
 							+ "      \"userPhoneNumber\": \"010-0000-0000\",\n"
 							+ "      \"role\": \"PROJECT_ADMIN\"\n"
 							+ "    }\n"
-							+ "  ]\n"
-							+ "}"
-					),
+								+ "  ]\n"
+								+ "}"
+						),
 					@ExampleObject(
 						name = "프로젝트 목록 조회",
-						value = "[\n"
-							+ "  {\n"
-							+ "    \"projectId\": \"0cc61cc8ed964714a06a42afa92c1dc6\",\n"
-							+ "    \"projectName\": \"admin\",\n"
-							+ "    \"projectType\": \"PROJECT_REQUEST_TYPE/ETC\",\n"
-							+ "    \"createdBy\": null,\n"
-							+ "    \"createdAt\": \"1900-01-01T00:00\",\n"
-							+ "    \"status\": \"APPROVED\",\n"
-							+ "    \"projectBrief\": {\n"
-							+ "      \"vCpu\": 8,\n"
-							+ "      \"vRam\": 32,\n"
-							+ "      \"instance\": 10,\n"
-							+ "      \"storage\": 1000\n"
-							+ "    },\n"
-							+ "    \"participants\": [],\n"
-							+ "    \"rejectReason\": null\n"
-							+ "  },\n"
-							+ "  {\n"
-							+ "    \"projectId\": \"547b772d43684321991cbde58f06a264\",\n"
-							+ "    \"projectName\": \"ACCSwaggerProjectCreateTest\",\n"
-							+ "    \"projectType\": \"PROJECT_REQUEST_TYPE/ETC\",\n"
-							+ "    \"createdBy\": null,\n"
-							+ "    \"createdAt\": \"2025-11-26T17:59:53.229554\",\n"
-							+ "    \"status\": \"APPROVED\",\n"
-							+ "    \"projectBrief\": {\n"
-							+ "      \"vCpu\": 8,\n"
-							+ "      \"vRam\": 32,\n"
-							+ "      \"instance\": 10,\n"
-							+ "      \"storage\": 1000\n"
-							+ "    },\n"
-							+ "    \"participants\": [],\n"
-							+ "    \"rejectReason\": null\n"
-							+ "  },\n"
-							+ "  {\n"
-							+ "    \"projectId\": \"95282c49df5d47f68bb79bf4ad63a69b\",\n"
-							+ "    \"projectName\": \"AccTestProject\",\n"
-							+ "    \"projectType\": \"PROJECT_REQUEST_TYPE/ETC\",\n"
-							+ "    \"createdBy\": null,\n"
-							+ "    \"createdAt\": \"2025-11-26T17:59:53.232417\",\n"
-							+ "    \"status\": \"APPROVED\",\n"
-							+ "    \"projectBrief\": {\n"
-							+ "      \"vCpu\": 8,\n"
-							+ "      \"vRam\": 32,\n"
-							+ "      \"instance\": 10,\n"
-							+ "      \"storage\": 1000\n"
-							+ "    },\n"
-							+ "    \"participants\": [],\n"
-							+ "    \"rejectReason\": null\n"
-							+ "  },\n"
-							+ "  {\n"
-							+ "    \"projectId\": null,\n"
-							+ "    \"projectName\": \"abcabcasefes\",\n"
-							+ "    \"projectType\": \"PROJECT_REQUEST_TYPE/CAPSTONE_DESIGN\",\n"
-							+ "    \"createdBy\": {\n"
-							+ "      \"userId\": \"de15e36af072460da2e39a74be3595b6\",\n"
-							+ "      \"userName\": \"Acc_test_Admin1\"\n"
-							+ "    },\n"
-							+ "    \"createdAt\": \"2025-11-24T02:00:31.440323\",\n"
-							+ "    \"status\": \"PENDING\",\n"
-							+ "    \"projectBrief\": {\n"
-							+ "      \"vCpu\": 8,\n"
-							+ "      \"vRam\": 32,\n"
-							+ "      \"instance\": 10,\n"
-							+ "      \"storage\": 1000\n"
-							+ "    },\n"
-							+ "    \"participants\": [\n"
-							+ "      {\n"
-							+ "        \"userId\": \"de15e36af072460da2e39a74be3595b6\",\n"
-							+ "        \"userName\": \"Acc_test_Admin1\",\n"
-							+ "        \"userEmail\": null,\n"
-							+ "        \"userPhoneNumber\": null,\n"
-							+ "        \"role\": \"PROJECT_ADMIN\"\n"
-							+ "      }\n"
-							+ "    ],\n"
-							+ "    \"rejectReason\": null\n"
-							+ "  },\n"
-							+ "  {\n"
-							+ "    \"projectId\": null,\n"
-							+ "    \"projectName\": \"가나다라마바사\",\n"
-							+ "    \"projectType\": \"PROJECT_REQUEST_TYPE/MAJOR_LECTURE\",\n"
-							+ "    \"createdBy\": {\n"
-							+ "      \"userId\": \"de15e36af072460da2e39a74be3595b6\",\n"
-							+ "      \"userName\": \"Acc_test_Admin1\"\n"
-							+ "    },\n"
-							+ "    \"createdAt\": \"2025-11-25T02:14:58.849064\",\n"
-							+ "    \"status\": \"PENDING\",\n"
-							+ "    \"projectBrief\": {\n"
-							+ "      \"vCpu\": 8,\n"
-							+ "      \"vRam\": 32,\n"
-							+ "      \"instance\": 10,\n"
-							+ "      \"storage\": 1000\n"
-							+ "    },\n"
-							+ "    \"participants\": [\n"
-							+ "      {\n"
-							+ "        \"userId\": \"de15e36af072460da2e39a74be3595b6\",\n"
-							+ "        \"userName\": \"Acc_test_Admin1\",\n"
-							+ "        \"userEmail\": null,\n"
-							+ "        \"userPhoneNumber\": null,\n"
-							+ "        \"role\": \"PROJECT_ADMIN\"\n"
-							+ "      }\n"
-							+ "    ],\n"
-							+ "    \"rejectReason\": null\n"
-							+ "  }\n"
-							+ "]"
+						value = """
+							[
+							  {
+							    "projectId": "0cc61cc8ed964714a06a42afa92c1dc6",
+							    "projectName": "admin",
+							    "projectType": "PROJECT_REQUEST_TYPE/ETC",
+							    "createdBy": null,
+							    "createdAt": "1900-01-01T00:00",
+							    "status": "APPROVED",
+							    "quota": {
+							      "instance": { "available": 10, "used": 2 },
+							      "core": { "available": 20, "used": 2 },
+							      "ram": { "available": 51200, "used": 1024 },
+							      "volume": {
+							        "count": { "available": 10, "used": 2 },
+							        "size": { "available": 1000, "used": 30 }
+							      }
+							    },
+							    "participants": [],
+							    "rejectReason": null
+							  },
+							  {
+							    "projectId": null,
+							    "projectName": "캡스톤 프로젝트 요청",
+							    "projectType": "PROJECT_REQUEST_TYPE/CAPSTONE_DESIGN",
+							    "createdBy": {
+							      "userId": "de15e36af072460da2e39a74be3595b6",
+							      "userName": "Acc_test_Admin1"
+							    },
+							    "createdAt": "2025-11-24T02:00:31.440323",
+							    "status": "PENDING",
+							    "quota": {
+							      "instance": { "available": 10, "used": 0 },
+							      "core": { "available": 8, "used": 0 },
+							      "ram": { "available": 32768, "used": 0 },
+							      "volume": {
+							        "count": { "available": 10, "used": 0 },
+							        "size": { "available": 1024, "used": 0 }
+							      }
+							    },
+							    "participants": [
+							      {
+							        "userId": "de15e36af072460da2e39a74be3595b6",
+							        "userName": "Acc_test_Admin1",
+							        "userEmail": null,
+							        "userPhoneNumber": null,
+							        "role": "PROJECT_ADMIN"
+							      }
+							    ],
+							    "rejectReason": null
+							  }
+							]
+							"""
 					)
 				},
-				schema = @Schema(oneOf = {ProjectResponse.class, List.class})
+				schema = @Schema(oneOf = {GetProjectResponse.class, ProjectResponse.class, List.class})
 			)
 		),
 		@ApiResponse(responseCode = "400", description = "잘못된 요청 - 요청 파라미터 오류", content = @Content()),
@@ -463,48 +242,37 @@ public interface ProjectDocs {
 				examples = {
 					@ExampleObject(
 						name = "프로젝트 생성요청 목록 조회",
-						value = "{\n"
-							+ "  \"contents\": [\n"
-							+ "    {\n"
-							+ "      \"projectRequestId\": \"ad1af0b6-0ac7-4005-95b9-9b0a325f00a9\",\n"
-							+ "      \"projectName\": \"abcabcasefes\",\n"
-							+ "      \"projectType\": \"PROJECT_REQUEST_TYPE/CAPSTONE_DESIGN\",\n"
-							+ "      \"createdBy\": {\n"
-							+ "        \"userId\": \"f52f7447cba1476da8fa281bf6fff220\",\n"
-							+ "        \"userName\": \"Waccounttest_1\"\n"
-							+ "      },\n"
-							+ "      \"createdAt\": \"2025-11-24T02:04:36.473286\",\n"
-							+ "      \"status\": \"APPROVED\",\n"
-							+ "      \"projectBrief\": {\n"
-							+ "        \"vCpu\": 8,\n"
-							+ "        \"vRam\": 32,\n"
-							+ "        \"instance\": 10,\n"
-							+ "        \"storage\": 1000\n"
-							+ "      }\n"
-							+ "    },\n"
-							+ "    {\n"
-							+ "      \"projectRequestId\": \"bb02de58-1376-4e6d-b676-6b088f4c41f5\",\n"
-							+ "      \"projectName\": \"abcabcasefes\",\n"
-							+ "      \"projectType\": \"PROJECT_REQUEST_TYPE/CAPSTONE_DESIGN\",\n"
-							+ "      \"createdBy\": {\n"
-							+ "        \"userId\": \"f52f7447cba1476da8fa281bf6fff220\",\n"
-							+ "        \"userName\": \"Waccounttest_1\"\n"
-							+ "      },\n"
-							+ "      \"createdAt\": \"2025-11-24T02:00:31.440323\",\n"
-							+ "      \"status\": \"PENDING\",\n"
-							+ "      \"projectBrief\": {\n"
-							+ "        \"vCpu\": 8,\n"
-							+ "        \"vRam\": 32,\n"
-							+ "        \"instance\": 10,\n"
-							+ "        \"storage\": 1000\n"
-							+ "      }\n"
-							+ "    }\n"
-							+ "  ],\n"
-							+ "  \"first\": true,\n"
-							+ "  \"last\": false,\n"
-							+ "  \"size\": 2,\n"
-							+ "  \"nextMarker\": \"MA==\"\n"
-							+ "}"
+						value = """
+							{
+							  "contents": [
+							    {
+							      "projectRequestId": "ad1af0b6-0ac7-4005-95b9-9b0a325f00a9",
+							      "projectName": "캡스톤 프로젝트 요청",
+							      "projectType": "PROJECT_REQUEST_TYPE/CAPSTONE_DESIGN",
+							      "createdBy": {
+							        "userId": "f52f7447cba1476da8fa281bf6fff220",
+							        "userName": "Waccounttest_1"
+							      },
+							      "createdAt": "2025-11-24T02:04:36.473286",
+							      "status": "PENDING",
+							      "quota": {
+							        "instance": { "available": 10, "used": 0 },
+							        "core": { "available": 8, "used": 0 },
+							        "ram": { "available": 32768, "used": 0 },
+							        "volume": {
+							          "count": { "available": 10, "used": 0 },
+							          "size": { "available": 1024, "used": 0 }
+							        }
+							      }
+							    }
+							  ],
+							  "first": true,
+							  "last": false,
+							  "size": 1,
+							  "nextMarker": "ad1af0b6-0ac7-4005-95b9-9b0a325f00a9",
+							  "prevMarker": null
+							}
+							"""
 					)
 				},
 				schema = @Schema(oneOf = {ProjectRequestResponse.class, PageResponse.class})

--- a/src/main/java/com/acc/local/dto/project/ProjectRequestDto.java
+++ b/src/main/java/com/acc/local/dto/project/ProjectRequestDto.java
@@ -21,7 +21,7 @@ public record ProjectRequestDto(
 	LocalDateTime createdAt,
 	ProjectRequestStatus status,
 	String rejectReason,
-	ProjectGlobalQuotaDto projectBrief
+	ProjectGlobalQuotaDto quota
 ) {
 	public static ProjectRequestDto from(ProjectRequestEntity projectRequestEntity) {
 		return ProjectRequestDto.builder()
@@ -33,17 +33,18 @@ public record ProjectRequestDto(
 			.createdAt(projectRequestEntity.getCreatedAt())
 			.status(projectRequestEntity.getStatus())
 			.rejectReason(projectRequestEntity.getRejectReason())
-			.projectBrief(ProjectGlobalQuotaDto.getDefault())
+			.quota(ProjectGlobalQuotaDto.getDefault())
 			.build();
 	}
 
     public ProjectCreateDto toProjectCreateDto(String approvedUserId) {
+		ProjectGlobalQuotaDto requestQuota = quota == null ? ProjectGlobalQuotaDto.getDefault() : quota;
 		return ProjectCreateDto.builder()
 				.projectOwnerId(requestUserId)
 				.projectDescription(getProjectDescriptionMessage(projectRequestId, approvedUserId))
 				.projectName(projectName)
 				.projectType(projectType)
-				.quota(ProjectQuotaRequest.from(projectBrief))
+				.quota(ProjectQuotaRequest.from(requestQuota))
 				.build();
     }
 

--- a/src/main/java/com/acc/local/dto/project/ProjectRequestResponse.java
+++ b/src/main/java/com/acc/local/dto/project/ProjectRequestResponse.java
@@ -15,9 +15,12 @@ public record ProjectRequestResponse(
 	ProjectOwnerDto createdBy,
 	String createdAt,
 	ProjectRequestStatus status,
-	ProjectGlobalQuotaDto projectBrief
+	ProjectGlobalQuotaDto quota
 ) {
 	public static ProjectRequestResponse from(ProjectRequestDto projectRequest, UserKeystoneDto createdBy) {
+		ProjectGlobalQuotaDto quota = projectRequest.quota() == null
+			? ProjectGlobalQuotaDto.getDefault()
+			: projectRequest.quota();
 		return ProjectRequestResponse.builder()
 			.projectRequestId(projectRequest.projectRequestId())
 			.projectName(projectRequest.projectName())
@@ -25,7 +28,7 @@ public record ProjectRequestResponse(
 			.createdBy(ProjectOwnerDto.from(createdBy))
 			.createdAt(projectRequest.createdAt().toString())
 			.status(projectRequest.status())
-			.projectBrief(ProjectGlobalQuotaDto.getDefault())
+			.quota(quota)
 			.build();
 	}
 }

--- a/src/main/java/com/acc/local/dto/project/ProjectResponse.java
+++ b/src/main/java/com/acc/local/dto/project/ProjectResponse.java
@@ -19,7 +19,6 @@ public record ProjectResponse(
 	ProjectOwnerDto createdBy,
 	String createdAt,
 	ProjectRequestStatus status,
-	@Deprecated ProjectGlobalQuotaDto projectBrief,
 	ProjectGlobalQuotaDto quota,
 	List<ProjectParticipantDto> participants,
 	String rejectReason
@@ -60,7 +59,6 @@ public record ProjectResponse(
 			.createdBy(owner == null ? null : ProjectOwnerDto.from(owner))
 			.createdAt(createdAt)
 			.status(projectServiceDto.status())
-			.projectBrief(quota)
 			.quota(quota)
 			.participants(participants)
 			.build();
@@ -74,7 +72,6 @@ public record ProjectResponse(
 			.createdBy(ProjectOwnerDto.from(projectRequestUser))
 			.createdAt(projectRequestDto.createdAt().toString())
 			.status(projectRequestDto.status())
-			.projectBrief(ProjectGlobalQuotaDto.getDefault())
 			.quota(ProjectGlobalQuotaDto.getDefault())
 			.rejectReason(projectRequestDto.rejectReason())
 			.participants(List.of(

--- a/src/main/java/com/acc/local/dto/project/quota/ProjectQuotaRequest.java
+++ b/src/main/java/com/acc/local/dto/project/quota/ProjectQuotaRequest.java
@@ -20,12 +20,12 @@ public record ProjectQuotaRequest(
 	@Schema(description = "인스턴스 최대 개수", requiredMode = Schema.RequiredMode.REQUIRED, example = "10")
 	int instance
 ) {
-    public static ProjectQuotaRequest from(ProjectGlobalQuotaDto projectBrief) {
+    public static ProjectQuotaRequest from(ProjectGlobalQuotaDto quota) {
         return ProjectQuotaRequest.builder()
-				.vCpu(projectBrief.core().available())
-				.vRam(projectBrief.ram().available())
-				.storage(projectBrief.volume().size().available())
-				.instance(projectBrief.instance().available())
+				.vCpu(quota.core().available())
+				.vRam(quota.ram().available())
+				.storage(quota.volume().size().available())
+				.instance(quota.instance().available())
 				.build();
     }
 }

--- a/src/test/java/com/acc/local/dto/project/ProjectRequestResponseTest.java
+++ b/src/test/java/com/acc/local/dto/project/ProjectRequestResponseTest.java
@@ -1,0 +1,41 @@
+package com.acc.local.dto.project;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+
+import com.acc.local.domain.enums.project.ProjectRequestStatus;
+import com.acc.local.domain.enums.project.ProjectRequestType;
+import com.acc.local.dto.auth.UserKeystoneDto;
+import com.acc.local.dto.project.quota.ProjectGlobalQuotaDto;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class ProjectRequestResponseTest {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Test
+	void fromSerializesQuotaWithoutDeprecatedProjectBrief() throws Exception {
+		ProjectRequestDto projectRequest = ProjectRequestDto.builder()
+			.projectRequestId("request-id")
+			.projectName("project-name")
+			.projectType(ProjectRequestType.ETC)
+			.createdAt(LocalDateTime.of(2026, 6, 18, 10, 10))
+			.status(ProjectRequestStatus.PENDING)
+			.quota(ProjectGlobalQuotaDto.getDefault())
+			.build();
+		UserKeystoneDto requester = UserKeystoneDto.builder()
+			.id("requester-id")
+			.name("requester")
+			.build();
+
+		ProjectRequestResponse response = ProjectRequestResponse.from(projectRequest, requester);
+
+		JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(response));
+		assertThat(json.has("projectBrief")).isFalse();
+		assertThat(json.has("quota")).isTrue();
+	}
+}

--- a/src/test/java/com/acc/local/dto/project/ProjectResponseTest.java
+++ b/src/test/java/com/acc/local/dto/project/ProjectResponseTest.java
@@ -1,0 +1,61 @@
+package com.acc.local.dto.project;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+
+import com.acc.local.domain.enums.project.ProjectRequestStatus;
+import com.acc.local.domain.enums.project.ProjectRequestType;
+import com.acc.local.dto.auth.UserKeystoneDto;
+import com.acc.local.dto.project.quota.ProjectGlobalQuotaDto;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class ProjectResponseTest {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Test
+	void fromProjectServiceDtoSerializesQuotaWithoutDeprecatedProjectBrief() throws Exception {
+		ProjectServiceDto project = ProjectServiceDto.builder()
+			.projectId("project-id")
+			.projectName("project-name")
+			.projectType(ProjectRequestType.ETC)
+			.status(ProjectRequestStatus.APPROVED)
+			.quota(ProjectGlobalQuotaDto.getDefault())
+			.build();
+		UserKeystoneDto owner = UserKeystoneDto.builder()
+			.id("owner-id")
+			.name("owner")
+			.build();
+
+		ProjectResponse response = ProjectResponse.from(project, owner, new ArrayList<>());
+
+		JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(response));
+		assertThat(json.has("projectBrief")).isFalse();
+		assertThat(json.has("quota")).isTrue();
+	}
+
+	@Test
+	void fromProjectRequestDtoSerializesQuotaWithoutDeprecatedProjectBrief() throws Exception {
+		ProjectRequestDto projectRequest = ProjectRequestDto.builder()
+			.projectName("pending-project")
+			.projectType(ProjectRequestType.CAPSTONE_DESIGN)
+			.createdAt(LocalDateTime.of(2026, 6, 18, 10, 0))
+			.status(ProjectRequestStatus.PENDING)
+			.build();
+		UserKeystoneDto requester = UserKeystoneDto.builder()
+			.id("requester-id")
+			.name("requester")
+			.build();
+
+		ProjectResponse response = ProjectResponse.from(projectRequest, requester);
+
+		JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(response));
+		assertThat(json.has("projectBrief")).isFalse();
+		assertThat(json.has("quota")).isTrue();
+	}
+}

--- a/src/test/java/com/acc/local/service/adapters/project/AdminProjectServiceAdapterTest.java
+++ b/src/test/java/com/acc/local/service/adapters/project/AdminProjectServiceAdapterTest.java
@@ -178,7 +178,7 @@ class AdminProjectServiceAdapterTest {
                 .projectType(ProjectRequestType.CAPSTONE_DESIGN)
                 .status(ProjectRequestStatus.PENDING)
                 .createdAt(LocalDateTime.now())
-                .projectBrief(ProjectGlobalQuotaDto.getDefault())
+                .quota(ProjectGlobalQuotaDto.getDefault())
                 .build();
     }
 


### PR DESCRIPTION
## 📌 변경 요약 (Summary)

> 이 PR에서 무엇을 변경했는지 간단히 설명해주세요.

- 프로젝트 목록 응답에서 하위 호환용으로 남아있던 `projectBrief` 필드를 제거하고 `quota`만 응답하도록 정리했습니다.
- 프로젝트 생성요청 목록 응답의 쿼터 필드를 `projectBrief`에서 `quota`로 통일했습니다.
- 사용자/관리자 프로젝트 및 프로젝트 생성요청 Swagger 예시와 스키마가 실제 응답과 일치하도록 수정했습니다.

---

## 🔗 관련 이슈 (Related Issue)

> 이 PR과 관련된 이슈를 작성해주세요.

Closes #27

---

## 🛠 작업 내용 / 작업 순서 (Implementation Details)

> 이번 작업에서 수행한 내용이나 작업 순서를 작성해주세요.

1. #27 이슈 본문과 코멘트 맥락 확인
2. FE 반영 완료 코멘트에 따라 `ProjectResponse.projectBrief` 제거
3. `ProjectRequestDto`, `ProjectRequestResponse`, `ProjectQuotaRequest`의 생성요청 쿼터 필드명을 `quota`로 통일
4. 사용자/관리자 프로젝트 목록 및 생성요청 목록 Swagger 예시 갱신
5. DTO 직렬화 테스트와 관련 서비스 테스트 추가/보정
6. 로컬 전체 자동 테스트 및 실제 API/Swagger 응답 검증
7. 테스트용 DB/Redis 리소스 정리

---

## ✨ 주요 변경 사항 (Key Changes)

- `ProjectResponse`에서 deprecated `projectBrief` record component와 builder 할당을 제거했습니다.
- `ProjectRequestResponse`가 생성요청 쿼터를 `quota` 필드로 직렬화하도록 변경했습니다.
- `ProjectRequestDto` 내부 필드와 승인 시 생성 DTO 변환 로직이 `quota` 명명으로 동작하도록 정리했습니다.
- Swagger/OpenAPI 문서에서 관련 프로젝트 응답 예시가 모두 `quota`를 사용하고 `projectBrief`를 노출하지 않도록 수정했습니다.
- DTO 직렬화 테스트에서 `projectBrief` 미노출과 `quota` 노출을 명시적으로 검증했습니다.

---

## 🧪 테스트 결과 (Test Results)

### 테스트 환경

- 로컬 Spring Boot 애플리케이션: `http://127.0.0.1:8080`
- 테스트 DB: `aolda-issue1-mariadb` MariaDB 컨테이너
- 테스트 Redis: `aolda-test-redis` Redis 컨테이너
- OpenStack 테스트 환경 연동
- 인증 방식: Redis에 테스트용 `SessionData`를 직접 생성하고 `acc-session-id` 쿠키로 API 호출

### 테스트 방법

1. 전체 자동 테스트 실행
   - `./gradlew test`
   - 결과: `BUILD SUCCESSFUL`

2. Swagger/OpenAPI 문서 검증
   - `/v3/api-docs` 호출
   - 전체 문서 내 `projectBrief_count=0` 확인
   - `/api/v1/projects`, `/api/v1/projects/request`, `/api/v1/admin/projects`, `/api/v1/admin/projects/request` 200 응답 예시에 `quota` 포함 및 `projectBrief` 미포함 확인

3. 실제 프로젝트 목록 API 호출
   - `GET /api/v1/projects`
   - `GET /api/v1/admin/projects?limit=1`
   - 결과: 200 응답, 첫 항목에 `quota` 존재 및 `projectBrief` 없음 확인

4. 실제 프로젝트 생성요청 목록 API 호출
   - 테스트용 프로젝트 생성요청 생성
   - `GET /api/v1/projects/request?keyword=issue27-quota-request-20260619-001&limit=1`
   - `GET /api/v1/admin/projects/request?keyword=issue27-quota-request-20260619-001&limit=1`
   - 결과: 200 응답, 첫 항목에 `quota` 존재 및 `projectBrief` 없음 확인

5. 테스트 리소스 정리 검증
   - DB `project_requests`, `outbox_events` 테스트 데이터 삭제
   - Redis 테스트 세션 삭제
   - 최종 잔여물 0건 확인

### 테스트 결과

- [x] 정상 동작 확인
- [x] 예외 상황 테스트
- [x] 기존 기능 영향 없음

검증 결과 요약:

```text
./gradlew test: BUILD SUCCESSFUL

OpenAPI:
projectBrief_count=0
/api/v1/projects: quota=true, projectBrief=false
/api/v1/projects/request: quota=true, projectBrief=false
/api/v1/admin/projects: quota=true, projectBrief=false
/api/v1/admin/projects/request: quota=true, projectBrief=false

실제 API:
GET /api/v1/projects -> 200, quota=true, projectBrief=false
GET /api/v1/admin/projects?limit=1 -> 200, quota=true, projectBrief=false
GET /api/v1/projects/request?keyword=issue27-quota-request-20260619-001&limit=1 -> 200, quota=true, projectBrief=false
GET /api/v1/admin/projects/request?keyword=issue27-quota-request-20260619-001&limit=1 -> 200, quota=true, projectBrief=false

정리 후 확인:
db_project_requests=0
db_outbox_events=0
redis_session_exists=0
```