### PR TITLE
[Fix] 프로젝트 명칭 형식 제한 문제 해결 #5

### DIFF
--- a/src/main/java/com/acc/global/exception/project/ProjectErrorCode.java
+++ b/src/main/java/com/acc/global/exception/project/ProjectErrorCode.java
@@ -12,6 +12,7 @@ public enum ProjectErrorCode implements ErrorCode {
 
     // 400 Bad Request
     INVALID_REQUEST_PARAMETER(400, "ACC-PROJECT-INVALID-REQUEST-PARAM", "필수 요청 파라미터가 누락되었거나 유효하지 않습니다."),
+    INVALID_PROJECT_NAME(400, "ACC-PROJECT-INVALID-PROJECT-NAME", "프로젝트명은 영어 소문자, 숫자, '-'만 사용할 수 있습니다."),
     INVALID_PROJECT_STATUS(400, "ACC-PROJECT-INVALID-PROJECT-STATUS", "잘못된 프로젝트 상태 값입니다."),
     INVALID_PROJECT_REQUEST_TYPE(400, "ACC-PROJECT-INVALID-PROJECT-REQUEST-TYPE", "올바르지 않은 프로젝트 요청타입 입니다."),
     INVALID_PROJECT_REQUEST_STATUS(400, "ACC-PROJECT-INVALID-PROJECT-REQUEST-STATUS", "올바르지 않은 프로젝트 요청상태 입니다."),

--- a/src/main/java/com/acc/local/controller/docs/ProjectDocs.java
+++ b/src/main/java/com/acc/local/controller/docs/ProjectDocs.java
@@ -537,7 +537,7 @@ public interface ProjectDocs {
 						name = "프로젝트 생성요청 등록 성공",
 						value = "{ \n"
 							+ "  \"projectRequestId\": \"f01213b2-6900-4086-b3fa-a1bbdd36765c\",\n"
-							+ "  \"projectName\": \"가나다라마바사\",\n"
+							+ "  \"projectName\": \"capstone-project\",\n"
 							+ "  \"projectType\": \"PROJECT_REQUEST_TYPE/MAJOR_LECTURE\",\n"
 							+ "  \"createdAt\": \"2025-11-25T02:14:58.849064\",\n"
 							+ "  \"status\": \"PENDING\",\n"

--- a/src/main/java/com/acc/local/dto/project/CreateProjectRequest.java
+++ b/src/main/java/com/acc/local/dto/project/CreateProjectRequest.java
@@ -6,7 +6,7 @@ import com.acc.local.dto.project.quota.ProjectQuotaRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record CreateProjectRequest(
-        @Schema(description = "프로젝트 이름", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "프로젝트 이름 (영어 소문자, 숫자, '-'만 허용)", requiredMode = Schema.RequiredMode.REQUIRED)
         String projectName,
 
         @Schema(description = "프로젝트 설명", requiredMode = Schema.RequiredMode.NOT_REQUIRED)

--- a/src/main/java/com/acc/local/dto/project/CreateProjectRequestRequest.java
+++ b/src/main/java/com/acc/local/dto/project/CreateProjectRequestRequest.java
@@ -5,7 +5,7 @@ import com.acc.local.domain.enums.project.ProjectRequestType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record CreateProjectRequestRequest(
-	@Schema(description = "프로젝트 이름") String projectName,
+	@Schema(description = "프로젝트 이름 (영어 소문자, 숫자, '-'만 허용)") String projectName,
 	@Schema(description = "프로젝트 유형") ProjectRequestType projectType,
 	@Schema(description = "프로젝트 설명 (최대 10,000자)") String projectDescription
 ) {}

--- a/src/main/java/com/acc/local/service/adapters/project/AdminProjectServiceAdapter.java
+++ b/src/main/java/com/acc/local/service/adapters/project/AdminProjectServiceAdapter.java
@@ -18,6 +18,7 @@ import com.acc.local.dto.project.quota.QuotaInformation;
 import com.acc.local.external.dto.keystone.KeystoneProject;
 import com.acc.local.service.modules.auth.AuthModule;
 import com.acc.local.service.modules.auth.KeystoneTokenModule;
+import com.acc.local.service.modules.auth.ProjectNameValidator;
 import com.acc.local.service.modules.auth.ProjectModule;
 import com.acc.local.service.modules.network.NeutronModule;
 import com.acc.local.service.modules.outbox.ProjectCreatedEvent;
@@ -51,6 +52,7 @@ public class AdminProjectServiceAdapter implements AdminProjectServicePort {
 	@Transactional
 	public CreateProjectResponse createProject(CreateProjectRequest createProjectRequest, String sessionId) {
 		String userId = sessionModule.getKeystoneUserId(sessionId);
+		ProjectNameValidator.validate(createProjectRequest.projectName());
 		// TODO: userId를 통해, 요청을 보낸 사람이 Root인지 권한 확인
 		String adminToken = authModule.issueSystemAdminTokenWithAdminProjectScope(userId);
 

--- a/src/main/java/com/acc/local/service/modules/auth/ProjectModule.java
+++ b/src/main/java/com/acc/local/service/modules/auth/ProjectModule.java
@@ -66,6 +66,7 @@ public class ProjectModule {
 
 	// ============ Project Request ============
 	public CreateProjectRequestResponse createProjectRequest(CreateProjectRequestRequest request, String requestUserId) {
+		ProjectNameValidator.validate(request.projectName());
 		checkIdenticalProjectRequestExist(request, requestUserId);
 
 		ProjectRequestEntity newRequest = ProjectRequestEntity.builder()
@@ -261,6 +262,8 @@ public class ProjectModule {
 	}
 
 	public KeystoneProject createProject(String adminToken, ProjectCreateDto request, String commandUserId) {
+		ProjectNameValidator.validate(request.projectName());
+
 		CreateKeystoneProjectRequest project = CreateKeystoneProjectRequest.builder()
 			.projectName(request.projectName())
 			.projectDescription(request.projectDescription())

--- a/src/main/java/com/acc/local/service/modules/auth/ProjectNameValidator.java
+++ b/src/main/java/com/acc/local/service/modules/auth/ProjectNameValidator.java
@@ -1,0 +1,20 @@
+package com.acc.local.service.modules.auth;
+
+import java.util.regex.Pattern;
+
+import com.acc.global.exception.project.ProjectErrorCode;
+import com.acc.global.exception.project.ProjectServiceException;
+
+public final class ProjectNameValidator {
+
+    private static final Pattern PROJECT_NAME_PATTERN = Pattern.compile("^[a-z0-9-]+$");
+
+    private ProjectNameValidator() {
+    }
+
+    public static void validate(String projectName) {
+        if (projectName == null || projectName.isBlank() || !PROJECT_NAME_PATTERN.matcher(projectName).matches()) {
+            throw new ProjectServiceException(ProjectErrorCode.INVALID_PROJECT_NAME);
+        }
+    }
+}

--- a/src/test/java/com/acc/local/service/adapters/project/AdminProjectServiceAdapterTest.java
+++ b/src/test/java/com/acc/local/service/adapters/project/AdminProjectServiceAdapterTest.java
@@ -4,7 +4,10 @@ import com.acc.local.domain.enums.project.ProjectRequestStatus;
 import com.acc.local.domain.enums.project.ProjectRequestType;
 import com.acc.global.common.PageRequest;
 import com.acc.global.common.PageResponse;
+import com.acc.global.exception.project.ProjectErrorCode;
+import com.acc.global.exception.project.ProjectServiceException;
 import com.acc.local.dto.auth.UserKeystoneDto;
+import com.acc.local.dto.project.CreateProjectRequest;
 import com.acc.local.dto.project.ProjectCreateDto;
 import com.acc.local.dto.project.DecideProjectRequestResponse;
 import com.acc.local.dto.project.ProjectListServiceDto;
@@ -14,6 +17,7 @@ import com.acc.local.dto.project.ProjectRequestResponse;
 import com.acc.local.dto.project.RepositoryPagination;
 import com.acc.local.dto.project.ProjectServiceDto;
 import com.acc.local.dto.project.quota.ProjectGlobalQuotaDto;
+import com.acc.local.dto.project.quota.ProjectQuotaRequest;
 import com.acc.local.external.dto.keystone.KeystoneProject;
 import com.acc.local.service.modules.auth.AuthModule;
 import com.acc.local.service.modules.auth.KeystoneTokenModule;
@@ -32,6 +36,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -64,6 +69,33 @@ class AdminProjectServiceAdapterTest {
 
     @InjectMocks
     private AdminProjectServiceAdapter adminProjectServiceAdapter;
+
+    @Test
+    @DisplayName("관리자 프로젝트 직접 생성 시 허용되지 않는 프로젝트명은 관리자 토큰 발급 전에 거부한다.")
+    void givenInvalidProjectName_whenCreateProject_thenThrowBeforeAdminTokenIssue() {
+        String sessionId = "session-id";
+        String adminUserId = "admin-user-id";
+        CreateProjectRequest request = new CreateProjectRequest(
+                "Invalid_Project",
+                "description",
+                ProjectRequestType.ETC,
+                ProjectQuotaRequest.builder()
+                        .vCpu(1)
+                        .vRam(1024)
+                        .storage(10)
+                        .instance(1)
+                        .build(),
+                "owner-user-id"
+        );
+
+        given(sessionModule.getKeystoneUserId(sessionId)).willReturn(adminUserId);
+
+        assertThatThrownBy(() -> adminProjectServiceAdapter.createProject(request, sessionId))
+                .isInstanceOfSatisfying(ProjectServiceException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(ProjectErrorCode.INVALID_PROJECT_NAME));
+        then(authModule).should(never()).issueSystemAdminTokenWithAdminProjectScope(anyString());
+        then(projectModule).shouldHaveNoInteractions();
+    }
 
     @Test
     @DisplayName("관리자 프로젝트 요청 목록은 모듈 pagination 정보를 API 응답으로 보존한다.")

--- a/src/test/java/com/acc/local/service/modules/auth/ProjectModuleTest.java
+++ b/src/test/java/com/acc/local/service/modules/auth/ProjectModuleTest.java
@@ -1,15 +1,22 @@
 package com.acc.local.service.modules.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 
 import com.acc.global.common.PageRequest;
+import com.acc.global.exception.project.ProjectErrorCode;
+import com.acc.global.exception.project.ProjectServiceException;
 import com.acc.local.domain.enums.project.ProjectRequestStatus;
 import com.acc.local.domain.enums.project.ProjectRequestType;
+import com.acc.local.dto.project.CreateProjectRequestRequest;
+import com.acc.local.dto.project.CreateProjectRequestResponse;
 import com.acc.local.dto.project.ProjectCreateDto;
 import com.acc.local.dto.project.ProjectRequestDto;
 import com.acc.local.dto.project.ProjectRequestListServiceDto;
@@ -70,6 +77,42 @@ class ProjectModuleTest {
 
     @InjectMocks
     private ProjectModule projectModule;
+
+    @Test
+    @DisplayName("프로젝트 요청 생성 시 영어 소문자, 숫자, 하이픈으로 구성된 프로젝트명은 저장한다.")
+    void givenValidProjectName_whenCreateProjectRequest_thenSaveRequest() {
+        CreateProjectRequestRequest request = new CreateProjectRequestRequest(
+                "valid-project-123",
+                ProjectRequestType.ETC,
+                "description"
+        );
+        given(projectRequestRepositoryPort.findAllByKeyword("valid-project-123", "owner-id"))
+                .willReturn(List.of());
+        given(projectRequestRepositoryPort.save(any(ProjectRequestEntity.class)))
+                .willAnswer(invocation -> persistedEntity(invocation.getArgument(0)));
+
+        CreateProjectRequestResponse response = projectModule.createProjectRequest(request, "owner-id");
+
+        assertThat(response.projectName()).isEqualTo("valid-project-123");
+        ArgumentCaptor<ProjectRequestEntity> requestCaptor = ArgumentCaptor.forClass(ProjectRequestEntity.class);
+        then(projectRequestRepositoryPort).should().save(requestCaptor.capture());
+        assertThat(requestCaptor.getValue().getProjectName()).isEqualTo("valid-project-123");
+    }
+
+    @Test
+    @DisplayName("프로젝트 요청 생성 시 허용되지 않는 프로젝트명은 저장 전에 거부한다.")
+    void givenInvalidProjectName_whenCreateProjectRequest_thenThrowBeforeSave() {
+        CreateProjectRequestRequest request = new CreateProjectRequestRequest(
+                "Invalid_Project",
+                ProjectRequestType.ETC,
+                "description"
+        );
+
+        assertThatThrownBy(() -> projectModule.createProjectRequest(request, "owner-id"))
+                .isInstanceOfSatisfying(ProjectServiceException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(ProjectErrorCode.INVALID_PROJECT_NAME));
+        then(projectRequestRepositoryPort).shouldHaveNoInteractions();
+    }
 
     @Test
     @DisplayName("프로젝트 요청 목록은 다음 데이터가 있을 때 현재 페이지 마지막 ID를 nextMarker로 반환한다.")
@@ -188,6 +231,29 @@ class ProjectModuleTest {
         assertThat(projectCaptor.getValue().getProjectType()).isEqualTo(ProjectRequestType.MAJOR_LECTURE);
     }
 
+    @Test
+    @DisplayName("프로젝트 생성 시 허용되지 않는 프로젝트명은 Keystone 호출 전에 거부한다.")
+    void givenInvalidProjectName_whenCreateProject_thenThrowBeforeExternalCall() {
+        ProjectCreateDto request = ProjectCreateDto.builder()
+                .projectName("Invalid_Project")
+                .projectDescription("description")
+                .projectType(ProjectRequestType.MAJOR_LECTURE)
+                .projectOwnerId("owner-user-id")
+                .quota(ProjectQuotaRequest.builder()
+                        .vCpu(4)
+                        .vRam(8192)
+                        .storage(100)
+                        .instance(2)
+                        .build())
+                .build();
+
+        assertThatThrownBy(() -> projectModule.createProject("admin-token", request, "admin-user-id"))
+                .isInstanceOfSatisfying(ProjectServiceException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(ProjectErrorCode.INVALID_PROJECT_NAME));
+        then(keystoneAPIExternalPort).should(never()).createProject(anyString(), any(CreateKeystoneProjectRequest.class));
+        then(projectRepositoryPort).shouldHaveNoInteractions();
+    }
+
     private ProjectRequestEntity entity(String id) {
         return ProjectRequestEntity.builder()
                 .projectRequestId(id)
@@ -196,6 +262,19 @@ class ProjectModuleTest {
                 .projectType(ProjectRequestType.ETC)
                 .status(ProjectRequestStatus.PENDING)
                 .projectDescription("description")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    private ProjectRequestEntity persistedEntity(ProjectRequestEntity entity) {
+        return ProjectRequestEntity.builder()
+                .projectRequestId(entity.getProjectRequestId())
+                .requestUserId(entity.getRequestUserId())
+                .projectName(entity.getProjectName())
+                .projectType(entity.getProjectType())
+                .status(entity.getStatus())
+                .projectDescription(entity.getProjectDescription())
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
                 .build();


### PR DESCRIPTION
## 📌 변경 요약 (Summary)

> 이 PR에서 무엇을 변경했는지 간단히 설명해주세요.

- 프로젝트 생성 요청 및 실제 프로젝트 생성 경로에서 프로젝트명을 영어 소문자, 숫자, `-`만 허용하도록 제한했습니다.
- 관리자 직접 생성 API에서는 시스템 관리자 토큰 발급 전에 잘못된 프로젝트명을 차단하도록 수정했습니다.

---

## 🔗 관련 이슈 (Related Issue)

> 이 PR과 관련된 이슈를 작성해주세요.

Closes #5

---

## 🛠 작업 내용 / 작업 순서 (Implementation Details)

> 이번 작업에서 수행한 내용이나 작업 순서를 작성해주세요.

1. GitHub 이슈 #5 및 연결된 GitLab 기존 이슈 #125 내용을 확인
2. 프로젝트 요청 생성 및 실제 프로젝트 생성 코드 경로 검토
3. `ProjectNameValidator` 추가로 프로젝트명 검증 규칙 중앙화
4. 사용자 프로젝트 요청 생성 시 저장 전에 프로젝트명 검증 적용
5. 관리자 직접 생성 시 시스템 관리자 토큰 발급 전에 프로젝트명 검증 적용
6. 실제 프로젝트 생성 직전에도 동일 검증 적용하여 승인/내부 생성 경로 방어
7. Swagger DTO 설명 및 생성요청 예시를 새 규칙에 맞게 수정
8. 단위 테스트 및 실제 백엔드 API 호출 기반 검증 수행

---

## ✨ 주요 변경 사항 (Key Changes)

- 프로젝트명 허용 형식: `^[a-z0-9-]+$`
- 신규 에러코드 추가:
  - `ACC-PROJECT-INVALID-PROJECT-NAME`
- 검증 적용 경로:
  - `POST /api/v1/projects/request`
  - `POST /api/v1/admin/projects`
  - 내부 실제 프로젝트 생성 경로 `ProjectModule.createProject`
- 관리자 직접 생성 API에서 invalid 프로젝트명은 OpenStack 토큰 발급 및 Keystone project 생성 이전에 차단됩니다.

---

## 🧪 테스트 결과 (Test Results)

### 테스트 환경

- 로컬 Spring Boot 애플리케이션: `http://127.0.0.1:8080`
- 테스트 DB: `aolda-issue1-mariadb` MariaDB 컨테이너
- 테스트 Redis: `aolda-test-redis` Redis 컨테이너
- OpenStack 테스트 환경 연동
- 인증 방식: Redis에 테스트용 `SessionData`를 직접 생성하고 `acc-session-id` 쿠키로 API 호출

### 테스트 방법

1. 자동 테스트 실행
   - `./gradlew test --tests com.acc.local.service.modules.auth.ProjectModuleTest --tests com.acc.local.service.adapters.project.AdminProjectServiceAdapterTest`
   - 결과: `BUILD SUCCESSFUL`

2. 전체 자동 테스트 실행
   - `./gradlew test`
   - 결과: `BUILD SUCCESSFUL`

3. 테스트 환경 기동 확인
   - Spring Boot 애플리케이션 `bootRun` 실행
   - `/actuator/health` 호출로 `UP` 확인
   - Docker MariaDB/Redis 연결 확인
   - OpenStack 초기 연결 로그 확인

4. Redis 테스트 세션 생성
   - 테스트용 `SessionData` 생성
   - `acc-session-id=issue5-project-name-test` 쿠키로 API 호출

5. 프로젝트 요청 생성 invalid name 테스트
   - `POST /api/v1/projects/request`
   - `projectName=Invalid_Project`
   - 결과: `400`
   - 응답 코드: `ACC-PROJECT-INVALID-PROJECT-NAME`

6. 관리자 프로젝트 직접 생성 invalid name 테스트
   - `POST /api/v1/admin/projects`
   - `projectName=Invalid_Project`
   - 결과: `400`
   - 응답 코드: `ACC-PROJECT-INVALID-PROJECT-NAME`
   - 서버 로그상 해당 invalid 요청에서 OpenStack 외부 호출 로그가 추가되지 않음을 확인

7. 프로젝트 요청 생성 valid name 테스트
   - `POST /api/v1/projects/request`
   - `projectName=issue5-valid-project-20260619-001`
   - 결과: `201`
   - 생성된 `projectRequestId=c292089c-f26f-4e9d-876f-2d6edd7a12e3`

8. 테스트 리소스 정리 검증
   - DB `project_requests` 테스트 데이터 삭제
   - DB `outbox_events` 테스트 데이터 삭제
   - Redis 테스트 세션 삭제
   - 최종 잔여물 0건 확인

### 테스트 결과

- [x] 정상 동작 확인
- [x] 예외 상황 테스트
- [x] 기존 기능 영향 없음

검증 결과 요약:

```text
./gradlew test: BUILD SUCCESSFUL

프로젝트 요청 생성 invalid name:
http_status=400
code=ACC-PROJECT-INVALID-PROJECT-NAME

관리자 프로젝트 직접 생성 invalid name:
http_status=400
code=ACC-PROJECT-INVALID-PROJECT-NAME
openstack_external_call_for_invalid_request=0

프로젝트 요청 생성 valid name:
http_status=201
projectRequestId=c292089c-f26f-4e9d-876f-2d6edd7a12e3

정리 후 확인:
db_project_requests=0
db_outbox_events=0
redis_session_deleted=1
invalid_project_requests=0
```

참고: #5 변경의 핵심은 invalid 프로젝트명이 OpenStack API로 전달되기 전에 차단되는지입니다. 따라서 valid 관리자 직접 생성으로 실제 Keystone/Neutron 리소스를 생성하는 테스트는 수행하지 않았습니다.